### PR TITLE
Fixing issue #15, #64, improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ server {
                 # First attempt to serve request as file, then
                 include uwsgi_params;
                 uwsgi_pass 172.19.199.3:8000;
-
+                uwsgi_read_timeout 300;
         }
 
 }

--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -2,25 +2,25 @@ FROM python:3.6-alpine
 
 MAINTAINER Abhilash Raj
 
-# Install the latest master branch of the mailman directly
-# from the Gitlab.
+#Add startup script to container
+ADD assets/run.sh /opt/run.sh
+
+#Install all required packages, add user for executing mailman and set execution rights for startup script
 RUN apk update \
     && apk add --virtual build-deps gcc python3-dev musl-dev \
     && apk add postgresql-dev bash su-exec postgresql-client \
     && pip install psycopg2 mailman==3.1.0 mailman-hyperkitty==1.1.0 \
-    && apk del build-deps
-
-ADD assets/run.sh /opt/run.sh
+    && apk del build-deps \
+    && adduser -S mailman \
+    && chmod a+x /opt/run.sh
 
 # Change the working directory.
 WORKDIR /opt/mailman
 
-EXPOSE 8001
-
-ENTRYPOINT ["/opt/run.sh"]
+#Expose the ports for the api (8001) and lmtp (8024)
+EXPOSE 8001 8024
 
 ENV MAILMAN_CONFIG_FILE /etc/mailman.cfg
 
-RUN adduser -S mailman
-
+ENTRYPOINT ["/opt/run.sh"]
 CMD ["/usr/local/bin/master"]

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -5,7 +5,7 @@ set -e
 curl -u restadmin:restpass http://172.19.199.2:8001/3.1/system
 
 # Check to see if postorius is working.
-curl -L http://172.19.199.3:8000/postorius/lists | grep "Mailing List"
+curl -L http://172.19.199.3:8080/postorius/lists | grep "Mailing List"
 
 # Check to see if hyperkitty is working.
-curl -L http://172.19.199.3:8000/hyperkitty/ | grep "Available lists"
+curl -L http://172.19.199.3:8080/hyperkitty/ | grep "Available lists"

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -39,4 +39,4 @@ EXPOSE 8000 8080
 STOPSIGNAL SIGINT
 
 ENTRYPOINT ["/opt/run.sh"]
-CMD uwsgi --ini /opt/mailman-web/uwsgi.ini
+CMD ["uwsgi", "--ini", "/opt/mailman-web/uwsgi.ini"]

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -3,7 +3,13 @@ FROM python:2.7
 MAINTAINER Abhilash Raj
 
 ENV DEBIAN_FRONTEND=noninteractive
+# Add needed files for uwsgi server + settings for django 
+ADD mailman-web /opt/mailman-web
+# Add startup script to container
+ADD assets/run.sh /opt/run.sh
 
+# Install packages and dependencies for postorius and hyperkitty
+# Add user for executing apps, change ownership for uwsgi+django files and set execution rights for management script
 RUN apt-get update \
     && apt-get install -y --no-install-recommends ruby-sass \
                        wget \
@@ -18,18 +24,19 @@ RUN apt-get update \
                              psycopg2 \
                              dj-database-url \
                              pymysql \
-	&& python -m pip install -U django==1.10
-
-ADD mailman-web /opt/mailman-web
-
-RUN useradd -M -U -u 1000 mailman
-
-ADD assets/run.sh /opt/run.sh
+	&& python -m pip install -U django==1.10 \
+    && useradd -M -U -u 1000 mailman \
+    && chmod u+x /opt/run.sh \
+    && chown mailman /opt/mailman-web/* \
+    && chmod u+x /opt/mailman-web/manage.py
 
 WORKDIR /opt/mailman-web
 
-EXPOSE 8000
+# Expose port 8000 for uwsgi and port 8080 for http
+EXPOSE 8000 8080
+
+# Use stop signal for uwsgi server
+STOPSIGNAL SIGINT
 
 ENTRYPOINT ["/opt/run.sh"]
-
-CMD ["uwsgi", "--ini", "/opt/mailman-web/uwsgi.ini"]
+CMD uwsgi --ini /opt/mailman-web/uwsgi.ini

--- a/web/mailman-web/uwsgi.ini
+++ b/web/mailman-web/uwsgi.ini
@@ -1,6 +1,10 @@
 [uwsgi]
 # Port on which uwsgi will be listening.
-http = :8000
+uwsgi-socket = 0.0.0.0:8000
+http-socket = 0.0.0.0:8080
+
+#Enable threading for python
+enable-threads = true
 
 # Move to the directory wher the django files are.
 chdir = /opt/mailman-web


### PR DESCRIPTION
This pull request will cause the following changes to improve the performance of docker-mailman
## web/mailman-web/uwsgi.ini
1. Removed the _http_ configuration tag because mostly uwsgi will not be exposed directly to the internet. [uwsgi HTTP explanation](http://uwsgi-docs.readthedocs.io/en/latest/HTTP.html)
2. Added _http-socket_ as consequence
3. Added _uwsgi-socket_ to support native uwsgi as recommended implementation

## README.md
1. Added uwsgi read timeout because sometimes the connection to the database can cause longer response times

## web/Dockerfile
1. Changed the order of the build commands to decrease size. Each statement will add a different header and increase size. Here is the changed order to shrink the overhead to min.
2. Changed the ownership and execution right. If somebody will download the code the permissions are not the correctly in every case
3. Added exposed port to support uwsgi and http
4. Added stopsignal to use default [uwsgi stop signal](http://uwsgi-docs.readthedocs.io/en/latest/Management.html) 

## core/Dockerfile
1. Changed the order of the build commands to decrease size. Each statement will add a different header and increase size. Here is the changed order to shrink the overhead to min.
2. Changed the ownership and execution right. If somebody will download the code the permissions are not the correctly in every case