### PR TITLE
Remove Facebook from default social auth provider.

### DIFF
--- a/web/mailman-web/settings.py
+++ b/web/mailman-web/settings.py
@@ -92,8 +92,6 @@ INSTALLED_APPS = (
     'allauth.socialaccount.providers.github',
     'allauth.socialaccount.providers.gitlab',
     'allauth.socialaccount.providers.google',
-    'allauth.socialaccount.providers.facebook',
-    #'allauth.socialaccount.providers.stackexchange',
 )
 
 


### PR DESCRIPTION
Fixes #73 