### PR TITLE
Fix uWSGI cron configuration

### DIFF
--- a/web/mailman-web/uwsgi.ini
+++ b/web/mailman-web/uwsgi.ini
@@ -25,11 +25,12 @@ gid = 1000
 attach-daemon = ./manage.py qcluster
 
 # Setup hyperkitty's cron jobs.
-cron2 = unique=1 ./manage.py runjobs minutely
-cron2 = hour=1,unique=1 ./manage.py runjobs hourly
-cron2 = day=1,unique=1 ./manage.py runjobs monthly
-cron2 = week=1,unique=1 ./manage.py runjobs weekly
-cron2 = month=1,unique=1 ./manage.py runjobs yearly
+unique-cron = -1 -1 -1 -1 -1 ./manage.py runjobs minutely
+unique-cron = 0 -1 -1 -1 -1 ./manage.py runjobs hourly
+unique-cron = 0 0 -1 -1 -1 ./manage.py runjobs daily
+unique-cron = 0 0 1 -1 -1 ./manage.py runjobs monthly
+unique-cron = 0 0 -1 -1 0 ./manage.py runjobs weekly
+unique-cron = 0 0 1 1 -1 ./manage.py runjobs yearly
 
 # Setup the request log.
 req-logger = file:/opt/mailman-web-data/logs/uwsgi.log

--- a/web/mailman-web/uwsgi.ini
+++ b/web/mailman-web/uwsgi.ini
@@ -26,6 +26,7 @@ attach-daemon = ./manage.py qcluster
 
 # Setup hyperkitty's cron jobs.
 unique-cron = -1 -1 -1 -1 -1 ./manage.py runjobs minutely
+unique-cron = -15 -1 -1 -1 -1 ./manage.py runjobs quarter_hourly
 unique-cron = 0 -1 -1 -1 -1 ./manage.py runjobs hourly
 unique-cron = 0 0 -1 -1 -1 ./manage.py runjobs daily
 unique-cron = 0 0 1 -1 -1 ./manage.py runjobs monthly


### PR DESCRIPTION
The missing daily routines are also added.

Close #87

P.S.: actually there's [quarter_hourly](https://github.com/django-extensions/django-extensions/blob/d195301ebbd002e98989cad05657f552cc54f96c/django_extensions/management/commands/runjobs.py#L61), but I choose to ignore it as postorious doesn't use it.