### PR TITLE
Recreate default domain and fix #94.

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,9 @@ mounted inside the containers.
 These are the settings that you MUST change before deploying:
 
 - `SERVE_FROM_DOMAIN`: The domain name from which Django will be served. To be
-  added to `ALLOWED_HOSTS` in django settings. Default value is not set.
+  added to `ALLOWED_HOSTS` in django settings. Default value is not set. This
+  also replaces Django's default `example.com` SITE and becomes the default SITE
+  (with SITE_ID=1).
 
 - `HYPERKITTY_API_KEY`: Hyperkitty's API Key, should be set to the same value as
   set for the mailman-core.

--- a/web/README.md
+++ b/web/README.md
@@ -12,7 +12,9 @@ Configuration
 These are the settings that you MUST change before deploying:
 
 - `SERVE_FROM_DOMAIN`: The domain name from which Django will be served. To be
-  added to `ALLOWED_HOSTS` in django settings. Default value is not set.
+  added to `ALLOWED_HOSTS` in django settings. Default value is not set. This
+  also replaces Django's default `example.com` SITE and becomes the default SITE
+  (with SITE_ID=1).
 
 - `HYPERKITTY_API_KEY`: Hyperkitty's API Key, should be set to the same value as
   set for the mailman-core.

--- a/web/assets/run.sh
+++ b/web/assets/run.sh
@@ -100,18 +100,17 @@ then
 		echo "Superuser $MAILMAN_ADMIN_USER already exists"
 fi
 
-# If MAILMAN_DEFAULT_DOMAIN is defined then rename the default `example.com`
+# If SERVE_FROM_DOMAIN is defined then rename the default `example.com`
 # domain to the defined domain.
-if [[ -v MAILMAN_DEFAULT_DOMAIN ]];
+if [[ -v SERVE_FROM_DOMAIN ]];
 then
 	echo "Setting $MAILMAN_DEFAULT_DOMAIN as the default domain ..."
 	python manage.py shell -c \
-	"from django.contrib.sites.models import Site; Site.objects.filter(domain='example.com').update(domain='$MAILMAN_DEFAULT_DOMAIN')"
+	"from django.contrib.sites.models import Site; Site.objects.filter(domain='example.com').update(domain='$SERVE_FROM_DOMAIN')"
 fi
 
 # Create a mailman user with the specific UID and GID and do not create home
 # directory for it. Also chown the logs directory to write the files.
 chown mailman:mailman /opt/mailman-web-data -R
-
 
 exec $@

--- a/web/assets/run.sh
+++ b/web/assets/run.sh
@@ -89,15 +89,24 @@ python manage.py collectstatic --noinput
 # this command will upgrade the database.
 python manage.py migrate
 
-
-
 # If MAILMAN_ADMIN_USER and MAILMAN_ADMIN_EMAIL is defined create a new
 # superuser for Django. There is no password setup so it can't login yet unless
 # the password is reset.
 if [[ -v MAILMAN_ADMIN_USER ]] && [[ -v MAILMAN_ADMIN_EMAIL ]];
 then
-	echo "Creating admin user..."
-	python manage.py createsuperuser --noinput --username "$MAILMAN_ADMIN_USER" --email "$MAILMAN_ADMIN_EMAIL"
+	echo "Creating admin user $MAILMAN_ADMIN_USER ..."
+	python manage.py createsuperuser --noinput --username "$MAILMAN_ADMIN_USER"\
+		   --email "$MAILMAN_ADMIN_EMAIL" 2> /dev/null || \
+		echo "Superuser $MAILMAN_ADMIN_USER already exists"
+fi
+
+# If MAILMAN_DEFAULT_DOMAIN is defined then rename the default `example.com`
+# domain to the defined domain.
+if [[ -v MAILMAN_DEFAULT_DOMAIN ]];
+then
+	echo "Setting $MAILMAN_DEFAULT_DOMAIN as the default domain ..."
+	python manage.py shell -c \
+	"from django.contrib.sites.models import Site; Site.objects.filter(domain='example.com').update(domain='$MAILMAN_DEFAULT_DOMAIN')"
 fi
 
 # Create a mailman user with the specific UID and GID and do not create home


### PR DESCRIPTION
Provided MAILMAN_DEFAULT_DOMAIN environment variable, rename example.com with
the provided domain name. Fix a bug where if the default username exists carry
on without creating the superuser.

Fixes #94 