### PR TITLE
Add automatic rewrite of mysql:// database URLs to mysql+pymysql:// URLs.

### DIFF
--- a/core/docker-entrypoint.sh
+++ b/core/docker-entrypoint.sh
@@ -58,6 +58,12 @@ function setup_database () {
 		exit 1
 	fi
 
+	# Translate mysql:// urls to mysql+mysql:// backend:
+	if [[ "$DATABASE_URL" == mysql://* ]]; then
+		DATABASE_URL="mysql+pymysql://${DATABASE_URL:8}"
+		echo "Database URL was automatically rewritten to: $DATABASE_URL"
+	fi
+
 	cat >> /etc/mailman.cfg <<EOF
 [database]
 class: $DATABASE_CLASS


### PR DESCRIPTION
This adds a section to the entrypoint script which rewrites `mysql://` database URLs to `mysql+pymysql://` URLs. This means that users won't be required to specify the MySQL backend, which in turn also will make it easier to change it later without breaking people's deployments.