### PR TITLE
Add code for auto-detecting database class for common cases (issue #137 )

### DIFF
--- a/core/docker-entrypoint.sh
+++ b/core/docker-entrypoint.sh
@@ -55,7 +55,7 @@ function setup_database () {
 		echo "Database URL was automatically rewritten to: $DATABASE_URL"
 	fi
 
-    # If DATABASE_CLASS is not set, guess it for common databases:
+	# If DATABASE_CLASS is not set, guess it for common databases:
 	if [ -z "$DATABASE_CLASS" ]; then
 		if [[ ("$DATABASE_URL" == mysql:*) ||
 				("$DATABASE_URL" == mysql+*) ]]; then

--- a/core/docker-entrypoint.sh
+++ b/core/docker-entrypoint.sh
@@ -56,16 +56,16 @@ function setup_database () {
 	fi
 
     # If DATABASE_CLASS is not set, guess it for common databases:
-    if [ -z "$DATABASE_CLASS" ]; then
-        if [[ ("$DATABASE_URL" == mysql:*) ||
-                ("$DATABASE_URL" == mysql+*) ]]; then
-            DATABASE_CLASS=mailman.database.mysql.MySQLDatabase
-        fi
-        if [[ ("$DATABASE_URL" == postgres:*) ||
-                ("$DATABASE_URL" == postgres+*) ]]; then
-            DATABASE_CLASS=mailman.database.postgresql.PostgreSQLDatabase
-        fi
-    fi
+	if [ -z "$DATABASE_CLASS" ]; then
+		if [[ ("$DATABASE_URL" == mysql:*) ||
+				("$DATABASE_URL" == mysql+*) ]]; then
+			DATABASE_CLASS=mailman.database.mysql.MySQLDatabase
+		fi
+		if [[ ("$DATABASE_URL" == postgres:*) ||
+				("$DATABASE_URL" == postgres+*) ]]; then
+			DATABASE_CLASS=mailman.database.postgresql.PostgreSQLDatabase
+		fi
+	fi
 
 	cat >> /etc/mailman.cfg <<EOF
 [database]

--- a/core/docker-entrypoint.sh
+++ b/core/docker-entrypoint.sh
@@ -64,6 +64,18 @@ function setup_database () {
 		echo "Database URL was automatically rewritten to: $DATABASE_URL"
 	fi
 
+    # If DATABASE_CLASS is not set, guess it for common databases:
+    if [ -z "$DATABASE_CLASS" ]; then
+        if [[ ("$DATABASE_URL" == mysql:*) ||
+                ("$DATABASE_URL" == mysql+*) ]]; then
+            DATABASE_CLASS=mailman.database.mysql.MySQLDatabase
+        fi
+        if [[ ("$DATABASE_URL" == postgres:*) ||
+                ("$DATABASE_URL" == postgres+*) ]]; then
+            DATABASE_CLASS=mailman.database.postgresql.PostgreSQLDatabase
+        fi
+    fi
+
 	cat >> /etc/mailman.cfg <<EOF
 [database]
 class: $DATABASE_CLASS


### PR DESCRIPTION
I implemented some code for auto-detecting the DATABASE_CLASS variable in `mailman-core` for common cases, to implement the enhancement suggested in issue #137 (at least for the common database providers MySQL and PostgreSQL).