### PR TITLE
Change hyperkitty and postorius paths to more general names

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -48,7 +48,7 @@ standard version of docker-compose.yaml from this repository.
 
 - `SMTP_PORT`: Port used for SMTP. Default is `25`.
 
-- `HYPERKITTY_API_URL`: Default value is `http://mailman-web:8000/hyperkitty`
+- `HYPERKITTY_API_URL`: Default value is `http://mailman-web:8000/archives`
 
 Running Mailman-Core
 ====================

--- a/core/assets/mailman-hyperkitty.cfg
+++ b/core/assets/mailman-hyperkitty.cfg
@@ -3,7 +3,7 @@
 # address will be used by Mailman to forward incoming emails to HyperKitty
 # for archiving. It does not need to be publicly available, in fact it's
 # better if it is not.
-base_url: http://mailman-web:8000/hyperkitty/
+base_url: http://mailman-web:8000/archives/
 # Shared API key, must be the identical to the value in HyperKitty's
 # settings.
 api_key: ASmallAPIKey

--- a/core/docker-entrypoint.sh
+++ b/core/docker-entrypoint.sh
@@ -144,8 +144,8 @@ if [[ ! -v HYPERKITTY_API_KEY ]]; then
 fi
 
 if [[ ! -v HYPERKITTY_URL ]]; then
-	echo "HYPERKITTY_URL not set, using the default value of http://mailman-web:8000/hyperkitty"
-	export HYPERKITTY_URL="http://mailman-web:8000/hyperkitty/"
+	echo "HYPERKITTY_URL not set, using the default value of http://mailman-web:8000/archives"
+	export HYPERKITTY_URL="http://mailman-web:8000/archives/"
 fi
 
 # Generate a basic mailman-hyperkitty.cfg.

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -29,7 +29,7 @@ docker logs mailman-core
 curl -u restadmin:restpass http://172.19.199.2:8001/3.1/system
 
 # Check to see if postorius is working.
-curl -L http://172.19.199.3:8000/postorius/lists | grep "Mailing List"
+curl -L http://172.19.199.3:8000/mailman3/lists | grep "Mailing List"
 
 # Check to see if hyperkitty is working.
-curl -L http://172.19.199.3:8000/hyperkitty/ | grep "Available lists"
+curl -L http://172.19.199.3:8000/archives/ | grep "Available lists"

--- a/web/mailman-web/urls.py
+++ b/web/mailman-web/urls.py
@@ -26,8 +26,8 @@ urlpatterns = [
     url(r'^$', RedirectView.as_view(
         url=reverse_lazy('list_index'),
         permanent=True)),
-    url(r'^postorius/', include('postorius.urls')),
-    url(r'^hyperkitty/', include('hyperkitty.urls')),
+    url(r'^mailman3/', include('postorius.urls')),
+    url(r'^archives/', include('hyperkitty.urls')),
     url(r'', include('django_mailman3.urls')),
     url(r'^accounts/', include('allauth.urls')),
     # Django admin


### PR DESCRIPTION
This streamlines the paths with 
* https://lists.fedoraproject.org/archives/
* https://lists.mailman3.org/archives/
* https://mail.python.org/mm3/archives/