### PR TITLE
Force start mailman inside the container.

### DIFF
--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -26,4 +26,4 @@ EXPOSE 8001 8024
 ENV MAILMAN_CONFIG_FILE /etc/mailman.cfg
 
 ENTRYPOINT ["docker-entrypoint.sh"]
-CMD ["master"]
+CMD ["master", "--force"]

--- a/core/docker-entrypoint.sh
+++ b/core/docker-entrypoint.sh
@@ -1,15 +1,6 @@
 #! /bin/bash
 set -e
 
-# Check if the master lock exists for the mailman.
-# It means that that either some other mailman process is running or
-# the last time mailman did not exit clean.
-if [[ -e /opt/mailman/var/locks/master.lck ]]; then
-	echo "The mailman's master lock file still exists at /opt/mailman/core/var/locks/master.lck"
-	echo "Please remove the lock file before trying to run this container again."
-	exit 1
-fi
-
 function wait_for_postgres () {
 	# Check if the postgres database is up and accepting connections before
 	# moving forward.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,6 +7,7 @@ services:
     hostname: mailman-core
     volumes:
     - /opt/mailman/core:/opt/mailman/
+    stop_grace_period: 30s
     links:
     - database:database
     depends_on:


### PR DESCRIPTION
Even though the 'master.lck' is supposed to prevent race conditions, it needs to
be manually removed if the container did not shutdown gracefully. Remove the
manual check for the lock file and force mailman to remove it.

Also, set the stop_grace_period to 30s, which would allow Core to stop
gracefully and not leave the lock file over. Default value in case of Docker is 10s.

Fixes #159 