### PR TITLE
Fix missing MIME types for static files

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -14,7 +14,7 @@ RUN set -ex \
 	&& apk add --no-cache --virtual .build-deps gcc libc-dev linux-headers \
 	   	postgresql-dev mariadb-dev \
 	&& apk add --no-cache --virtual .mailman-rundeps bash sassc \
-	   postgresql-client mysql-client py-mysqldb curl \
+	   postgresql-client mysql-client py-mysqldb curl mailcap \
 	&& pip install -U django==1.11 \
 	&& pip install mailmanclient==3.1.1 \
 		postorius==1.1.2 \


### PR DESCRIPTION
When running the mailman-web container with `UWSGI_STATIC_MAP=/static=/opt/mailman-web-data/static` (as suggested in https://github.com/maxking/docker-mailman#serving-static-files), the Browser receives the CSS files, but refuses to render them because of wrong MIME type (`text/plain`). Also, in the docker logs, a warning shows up that `/etc/mime.types` was not found.

According to the [Alpine package index](https://pkgs.alpinelinux.org/contents?branch=edge&name=mailcap&arch=armhf&repo=main), this file is now part of the `mailcap` package. Installing it in the container makes Postorius stop looking ugly again!