### PR TITLE
Install typing as it is required with django-extensions but not insta…

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -15,7 +15,7 @@ RUN set -ex \
 	   	postgresql-dev mariadb-dev \
 	&& apk add --no-cache --virtual .mailman-rundeps bash sassc \
 	   postgresql-client mysql-client py-mysqldb curl mailcap \
-	&& pip install -U django==1.11 \
+	&& pip install -U django==1.11 pip \
 	&& pip install mailmanclient==3.1.1 \
 		postorius==1.1.2 \
 		hyperkitty==1.1.4 \
@@ -25,6 +25,7 @@ RUN set -ex \
 		psycopg2 \
 		dj-database-url \
 		mysqlclient \
+		typing \
 	&& apk del .build-deps \
 	&& addgroup -S mailman \
 	&& adduser -S -G mailman mailman \


### PR DESCRIPTION
Django-extensions requires `typing` module but isn't installed on 2.7 release for some reason so we need to install it manually.