### PR TITLE
Do not try to get the Core's IP automatically

### DIFF
--- a/web/mailman-web/settings.py
+++ b/web/mailman-web/settings.py
@@ -27,7 +27,6 @@ https://docs.djangoproject.com/en/1.8/ref/settings/
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 import os
-import socket
 import dj_database_url
 import sys
 
@@ -57,15 +56,12 @@ ALLOWED_HOSTS = [
     os.environ.get('DJANGO_ALLOWED_HOSTS'),
 ]
 
-# Try to get the address of Mailman Core automatically.
-MAILMAN_HOST_IP_AUTO = socket.gethostbyname('mailman-core')
-
 # Mailman API credentials
 MAILMAN_REST_API_URL = os.environ.get('MAILMAN_REST_URL', 'http://mailman-core:8001')
 MAILMAN_REST_API_USER = os.environ.get('MAILMAN_REST_USER', 'restadmin')
 MAILMAN_REST_API_PASS = os.environ.get('MAILMAN_REST_PASSWORD', 'restpass')
 MAILMAN_ARCHIVER_KEY = os.environ.get('HYPERKITTY_API_KEY')
-MAILMAN_ARCHIVER_FROM = (MAILMAN_HOST_IP_AUTO, os.environ.get('MAILMAN_HOST_IP', '172.19.199.2'))
+MAILMAN_ARCHIVER_FROM = os.environ.get('MAILMAN_HOST_IP', '172.19.199.2')
 
 # Application definition
 


### PR DESCRIPTION
Without a try-except block, trying to get the IP of `mailman-core` fails when mailman-web is made to run standalone.