### PR TITLE
Fix #210: introduce MTA variable

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -52,6 +52,8 @@ standard version of docker-compose.yaml from this repository.
 - `MAILMAN_REST_PASSWORD`: Which password should Core use for the REST API. If
   not defined the default is `restpass`.
 
+- `MTA`: Mail Transfer Agent to use. Either `exim` or `postfix`. Default value is `exim`.
+
 - `SMTP_HOST`: IP Address/hostname from which you will be sending
   emails. Default value is `172.19.199.1`, which is the address of the Host OS.
 

--- a/core/docker-entrypoint.sh
+++ b/core/docker-entrypoint.sh
@@ -132,7 +132,7 @@ configuration: /etc/mailman-hyperkitty.cfg
 EOF
 
 # Generate a basic configuration to use exim
-cat > /etc/exim-mailman.cfg <<EOF
+cat > /tmp/exim-mailman.cfg <<EOF
 [mta]
 incoming: mailman.mta.exim4.LMTP
 outgoing: mailman.mta.deliver.deliver
@@ -144,7 +144,7 @@ configuration: python:mailman.config.exim4
 
 EOF
 
-cat > /etc/postfix-mailman-configuration.cfg << EOF
+cat > /etc/postfix-mailman.cfg << EOF
 [postfix]
 transport_file_type: regex
 # While in regex mode, postmap_command is never used, a placeholder
@@ -153,7 +153,7 @@ postmap_command: true
 EOF
 
 # Generate a basic configuration to use postfix.
-cat > /etc/postfix-mailman.cfg <<EOF
+cat > /tmp/postfix-mailman.cfg <<EOF
 [mta]
 incoming: mailman.mta.postfix.LMTP
 outgoing: mailman.mta.deliver.deliver
@@ -161,22 +161,24 @@ lmtp_host: $MM_HOSTNAME
 lmtp_port: 8024
 smtp_host: $SMTP_HOST
 smtp_port: $SMTP_PORT
-configuration: /etc/postfix-mailman-configuration.cfg
+configuration: /etc/postfix-mailman.cfg
 
 EOF
 
 if [ "$MTA" == "exim" ]
 then
 	echo "Using Exim configuration"
-	cat /etc/exim-mailman.cfg >> /etc/mailman.cfg
+	cat /tmp/exim-mailman.cfg >> /etc/mailman.cfg
 elif [ "$MTA" == "postfix" ]
 then
 	echo "Using Postfix configuration"
-	cat /etc/postfix-mailman.cfg >> /etc/mailman.cfg
+	cat /tmp/postfix-mailman.cfg >> /etc/mailman.cfg
 else
 	echo "No MTA environment variable found, defaulting to Exim"
-	cat /etc/exim-mailman.cfg >> /etc/mailman.cfg
+	cat /tmp/exim-mailman.cfg >> /etc/mailman.cfg
 fi
+
+rm -f /tmp/{postfix,exim}-mailman.cfg
 
 if [[ -e /opt/mailman/mailman-extra.cfg ]]
 then

--- a/core/docker-entrypoint.sh
+++ b/core/docker-entrypoint.sh
@@ -144,6 +144,14 @@ configuration: python:mailman.config.exim4
 
 EOF
 
+cat > /etc/postfix-mailman-configuration.cfg << EOF
+[postfix]
+transport_file_type: regex
+# While in regex mode, postmap_command is never used, a placeholder
+# is added here so that it doesn't break anything.
+postmap_command: true
+EOF
+
 # Generate a basic configuration to use postfix.
 cat > /etc/postfix-mailman.cfg <<EOF
 [mta]
@@ -153,7 +161,7 @@ lmtp_host: $MM_HOSTNAME
 lmtp_port: 8024
 smtp_host: $SMTP_HOST
 smtp_port: $SMTP_PORT
-configuration: python:mailman.config.postfix
+configuration: /etc/postfix-mailman-configuration.cfg
 
 EOF
 

--- a/core/docker-entrypoint.sh
+++ b/core/docker-entrypoint.sh
@@ -164,7 +164,7 @@ then
 elif [ "$MTA" == "postfix" ]
 then
 	echo "Using Postfix configuration"
-	cat /etc/postfix-maiman.cfg >> /etc/mailman.cfg
+	cat /etc/postfix-mailman.cfg >> /etc/mailman.cfg
 else
 	echo "No MTA environment variable found, defaulting to Exim"
 	cat /etc/exim-mailman.cfg >> /etc/mailman.cfg


### PR DESCRIPTION
Introduces an `MTA` environment variable, which is either `exim` or `postfix`.
For backwards compatibility, it defaults to `exim`.

With this PR you don't have to use a mailman-extra.cfg file just to switch from the default MTA (Exim) to Postfix.

In case `MTA=postfix`,  `/etc/mailman.cfg` is more clean as it only configures postfix and not (prior to this PR) both Exim and Postfix.