### PR TITLE
Update Exim config file examples

### DIFF
--- a/core/assets/exim/25_mm3_macros
+++ b/core/assets/exim/25_mm3_macros
@@ -1,11 +1,10 @@
 # Place this file at
 # /etc/exim4/conf.d/main/25_mm3_macros
 
-domainlist mm_domains=MY_DOMAIN_NAME
-
+domainlist mm3_domains=MY_DOMAIN_NAME
+MM3_LMTP_HOST=172.19.199.2
 MM3_LMTP_PORT=8024
 MM3_HOME=/opt/mailman/core/var
-
 
 ################################################################
 # The configuration below is boilerplate:

--- a/core/assets/exim/455_mm3_router
+++ b/core/assets/exim/455_mm3_router
@@ -3,7 +3,7 @@
 
 mailman3_router:
   driver = accept
-  domains = +mm_domains
+  domains = +mm3_domains
   require_files = MM3_LISTCHK
   local_part_suffix_optional
   local_part_suffix = -admin : \

--- a/core/assets/exim/55_mm3_transport
+++ b/core/assets/exim/55_mm3_transport
@@ -1,11 +1,11 @@
 # Place this file at
-# /etc/exim4/conf.d/router/55_mm3_transport
+# /etc/exim4/conf.d/transport/55_mm3_transport
 
 mailman3_transport:
   debug_print = "Email for mailman"
   driver = smtp
   protocol = lmtp
   allow_localhost
-  hosts = 172.18.0.3
-  port = 8024
+  hosts = MM3_LMTP_HOST
+  port = MM3_LMTP_PORT
   rcpt_include_affixes = true


### PR DESCRIPTION
This PR updates the Exim config examples as follows:

- Fix the path in the comments for the transport;
- Fix the IP address used (was set incorrectly in the example);
- Moved the host and port in the transport to use macros;
- Rename the macro MM_DOMAINS to MM3_DOMAINS so we don't conflict with sites that use the existing Mailman2 Exim config examples.