### PR TITLE
Use Python 3.6 instead of 3.7 (which :3 tag points to).

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: '2'
 jobs:
   build:
     docker:
-      - image: circleci/python:3
+      - image: circleci/python:3.6-stretch-browsers
     environment:
       REGISTRY: QUAY
       QUAY_URL: quay.io


### PR DESCRIPTION
PyYAML does't build with 3.7, so we should be using 3.6 instead.