### PR TITLE
WIP: Remove static IP and use host network.

### DIFF
--- a/core/docker-entrypoint.sh
+++ b/core/docker-entrypoint.sh
@@ -34,7 +34,7 @@ if [[ ! -v MM_HOSTNAME ]]; then
 fi
 
 if [[ ! -v SMTP_HOST ]]; then
-	export SMTP_HOST='172.19.199.1'
+	export SMTP_HOST='localhost'
 fi
 
 if [[ ! -v SMTP_PORT ]]; then

--- a/docker-compose-mysql.yaml
+++ b/docker-compose-mysql.yaml
@@ -4,11 +4,8 @@ services:
   mailman-core:
     image: maxking/mailman-core:latest
     container_name: mailman-core
-    hostname: mailman-core
     volumes:
     - /opt/mailman/core:/opt/mailman/
-    links:
-    - database:database
     depends_on:
     - database
     environment:
@@ -16,19 +13,14 @@ services:
     - DATABASE_TYPE=mysql
     - DATABASE_CLASS=mailman.database.mysql.MySQLDatabase
     - HYPERKITTY_API_KEY=someapikey
-    networks:
-      mailman:
-        ipv4_address: 172.19.199.2
+    network_mode: "host"
+
 
   mailman-web:
     image: maxking/mailman-web:latest
     container_name: mailman-web
-    hostname: mailman-web
     depends_on:
     - database
-    links:
-    - mailman-core:mailman-core
-    - database:database
     volumes:
     - /opt/mailman/web:/opt/mailman-web-data
     environment:
@@ -37,9 +29,8 @@ services:
     - HYPERKITTY_API_KEY=someapikey
     - SECRET_KEY=thisisaverysecretkey
     - DYLD_LIBRARY_PATH=/usr/local/mysql/lib/
-    networks:
-      mailman:
-        ipv4_address: 172.19.199.3
+    network_mode: "host"
+
 
   database:
     environment:
@@ -51,15 +42,4 @@ services:
     image: mariadb:10.3
     volumes:
     - /opt/mailman/database:/var/lib/mysql
-    networks:
-      mailman:
-        ipv4_address: 172.19.199.4
-
-networks:
-   mailman:
-     driver: bridge
-     ipam:
-       driver: default
-       config:
-       -
-         subnet: 172.19.199.0/24
+    network_mode: "host"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,60 +4,47 @@ services:
   mailman-core:
     image: maxking/mailman-core:0.2
     container_name: mailman-core
-    hostname: mailman-core
+    restart: on-failure
     volumes:
     - /opt/mailman/core:/opt/mailman/
     stop_grace_period: 30s
-    links:
-    - database:database
     depends_on:
     - database
     environment:
-    - DATABASE_URL=postgres://mailman:mailmanpass@database/mailmandb
+    - DATABASE_URL=postgres://mailman:mailmanpass@localhost/mailmandb
     - DATABASE_TYPE=postgres
     - DATABASE_CLASS=mailman.database.postgresql.PostgreSQLDatabase
     - HYPERKITTY_API_KEY=someapikey
-    networks:
-      mailman:
-        ipv4_address: 172.19.199.2
+    - MM_HOSTNAME=localhost
+    - SMTP_HOST=localhost
+    - HYPERKITTY_API_URL=http://localhost:8000/hyerpkitty
+    network_mode: "host"
+
 
   mailman-web:
     image: maxking/mailman-web:0.2
     container_name: mailman-web
-    hostname: mailman-web
+    restart: on-failure
     depends_on:
     - database
-    links:
-    - mailman-core:mailman-core
-    - database:database
     volumes:
     - /opt/mailman/web:/opt/mailman-web-data
     environment:
     - DATABASE_TYPE=postgres
-    - DATABASE_URL=postgres://mailman:mailmanpass@database/mailmandb
+    - DATABASE_URL=postgres://mailman:mailmanpass@localhost/mailmandb
     - HYPERKITTY_API_KEY=someapikey
-    networks:
-      mailman:
-        ipv4_address: 172.19.199.3
+    - UWSGI_STATIC_MAP=/static=/opt/mailman-web-data/static
+    - MAILMAN_REST_URL=http://localhost:8001
+    - MAILMAN_HOST_IP=127.0.0.1
+    network_mode: "host"
 
   database:
     environment:
       POSTGRES_DB: mailmandb
       POSTGRES_USER: mailman
       POSTGRES_PASSWORD: mailmanpass
-    restart: always
+    restart: on-failure
     image: postgres:9.6-alpine
     volumes:
     - /opt/mailman/database:/var/lib/postgresql/data
-    networks:
-      mailman:
-        ipv4_address: 172.19.199.4
-
-networks:
-   mailman:
-     driver: bridge
-     ipam:
-       driver: default
-       config:
-       -
-         subnet: 172.19.199.0/24
+    network_mode: "host"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -17,7 +17,7 @@ services:
     - HYPERKITTY_API_KEY=someapikey
     - MM_HOSTNAME=localhost
     - SMTP_HOST=localhost
-    - HYPERKITTY_API_URL=http://localhost:8000/hyerpkitty
+    - HYPERKITTY_URL=http://localhost:8000/hyerpkitty
     network_mode: "host"
 
 

--- a/web/mailman-web/settings.py
+++ b/web/mailman-web/settings.py
@@ -48,20 +48,17 @@ SITE_ID = 1
 # See https://docs.djangoproject.com/en/1.8/ref/settings/#allowed-hosts
 ALLOWED_HOSTS = [
     "localhost",  # Archiving API from Mailman, keep it.
-    # "lists.your-domain.org",
     # Add here all production URLs you may have.
-    "mailman-web",
-    "172.19.199.3",
     os.environ.get('SERVE_FROM_DOMAIN'),
     os.environ.get('DJANGO_ALLOWED_HOSTS'),
 ]
 
 # Mailman API credentials
-MAILMAN_REST_API_URL = os.environ.get('MAILMAN_REST_URL', 'http://mailman-core:8001')
+MAILMAN_REST_API_URL = os.environ.get('MAILMAN_REST_URL', 'http://localhost:8001')
 MAILMAN_REST_API_USER = os.environ.get('MAILMAN_REST_USER', 'restadmin')
 MAILMAN_REST_API_PASS = os.environ.get('MAILMAN_REST_PASSWORD', 'restpass')
 MAILMAN_ARCHIVER_KEY = os.environ.get('HYPERKITTY_API_KEY')
-MAILMAN_ARCHIVER_FROM = os.environ.get('MAILMAN_HOST_IP', '172.19.199.2')
+MAILMAN_ARCHIVER_FROM = os.environ.get('MAILMAN_HOST_IP', '127.0.0.1')
 
 # Application definition
 
@@ -236,11 +233,12 @@ SERVER_EMAIL = 'root@{}'.format(hostname)
 
 # Change this when you have a real email backend
 EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
-EMAIL_HOST = os.environ.get('SMTP_HOST', '172.19.199.1')
+EMAIL_HOST = os.environ.get('SMTP_HOST', 'localhost')
 EMAIL_PORT = os.environ.get('SMTP_PORT', 25)
 EMAIL_HOST_USER = ''
 EMAIL_HOST_PASSWORD = ''
 EMAIL_USE_TLS = False
+
 
 # Compatibility with Bootstrap 3
 from django.contrib.messages import constants as messages  # flake8: noqa
@@ -412,7 +410,7 @@ Q_CLUSTER = {
     'orm': 'default',
 }
 
-POSTORIUS_TEMPLATE_BASE_URL =  os.environ.get('POSTORIUS_TEMPLATE_BASE_URL', 'http://mailman-web:8000')
+POSTORIUS_TEMPLATE_BASE_URL =  os.environ.get('POSTORIUS_TEMPLATE_BASE_URL', 'http://localhost:8000')
 
 try:
     from settings_local import *


### PR DESCRIPTION
This is a big change and will result in a minor version bump. Removing the
assumption on IP addresses will make most of the setup quite easy and remove
all the hardcoded IPs.

The places which necessarily do require one can be based of 127.0.0.1, like
MAILMAN_HOST in Hyperkitty, which verifies the sender based on the incoming IP
address.