### PR TITLE
The SessionAuthenticationMiddleware class is removed from Django 2.0

### DIFF
--- a/postorius/mailman-web/settings.py
+++ b/postorius/mailman-web/settings.py
@@ -97,7 +97,6 @@ MIDDLEWARE = (
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.middleware.locale.LocaleMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'django.middleware.security.SecurityMiddleware',


### PR DESCRIPTION
As per https://docs.djangoproject.com/en/2.0/releases/2.0/ page,

_The SessionAuthenticationMiddleware class is removed. It provided no functionality since session authentication is unconditionally enabled in Django 1.10._

