### PR TITLE
Make MAILMAN_ARCHIVER_FROM a tuple

### DIFF
--- a/postorius/mailman-web/settings.py
+++ b/postorius/mailman-web/settings.py
@@ -63,7 +63,7 @@ ALLOWED_HOSTS = [
 MAILMAN_REST_API_URL = os.environ.get('MAILMAN_REST_URL', 'http://mailman-core:8001')
 MAILMAN_REST_API_USER = os.environ.get('MAILMAN_REST_USER', 'restadmin')
 MAILMAN_REST_API_PASS = os.environ.get('MAILMAN_REST_PASSWORD', 'restpass')
-MAILMAN_ARCHIVER_FROM = os.environ.get('MAILMAN_HOST_IP', '172.19.199.2')
+MAILMAN_ARCHIVER_FROM = (os.environ.get('MAILMAN_HOST_IP', '172.19.199.2'),)
 
 # Application definition
 

--- a/web/mailman-web/settings.py
+++ b/web/mailman-web/settings.py
@@ -61,7 +61,7 @@ MAILMAN_REST_API_URL = os.environ.get('MAILMAN_REST_URL', 'http://mailman-core:8
 MAILMAN_REST_API_USER = os.environ.get('MAILMAN_REST_USER', 'restadmin')
 MAILMAN_REST_API_PASS = os.environ.get('MAILMAN_REST_PASSWORD', 'restpass')
 MAILMAN_ARCHIVER_KEY = os.environ.get('HYPERKITTY_API_KEY')
-MAILMAN_ARCHIVER_FROM = os.environ.get('MAILMAN_HOST_IP', '172.19.199.2')
+MAILMAN_ARCHIVER_FROM = (os.environ.get('MAILMAN_HOST_IP', '172.19.199.2'),)
 
 # Application definition
 


### PR DESCRIPTION
From the Hyperkitty [code](https://gitlab.com/mailman/hyperkitty/blob/master/hyperkitty/views/mailman.py#L56) and [settings example](https://gitlab.com/mailman/hyperkitty/blob/master/example_project/settings.py#L47) I gather that the `MAILMAN_ARCHIVER_FROM` should be a sequence of strings and not a string.