### PR TITLE
Fix for MySQL port ignored by wait_for_mysql()

### DIFF
--- a/core/docker-entrypoint.sh
+++ b/core/docker-entrypoint.sh
@@ -16,11 +16,22 @@ function wait_for_postgres () {
 function wait_for_mysql () {
 	# Check if MySQL is up and accepting connections.
 	HOSTNAME=$(python3 -c "from urllib.parse import urlparse; o = urlparse('$DATABASE_URL'); print(o.hostname);")
-	until mysqladmin ping --host "$HOSTNAME" --silent; do
-		>&2 echo "MySQL is unavailable - sleeping"
-		sleep 1
-	done
-	>&2 echo "MySQL is up - continuing"
+	PORT=$(python3 -c "from urllib.parse import urlparse; o = urlparse('$DATABASE_URL'); print(o.port);")
+
+	if [[ $PORT  == "None" ]]
+	then
+		until mysqladmin ping --host "$HOSTNAME" --silent; do
+			>&2 echo "MySQL ($HOSTNAME) is unavailable - sleeping"
+			sleep 1
+		done
+		>&2 echo "MySQL is up - continuing"
+	else
+		until mysqladmin ping --host "$HOSTNAME" --port "$PORT" --silent; do
+			>&2 echo "MySQL ($HOSTNAME) is unavailable - sleeping"
+			sleep 1
+		done
+		>&2 echo "MySQL is up - continuing"
+	fi
 }
 
 # Empty the config file.

--- a/web/docker-entrypoint.sh
+++ b/web/docker-entrypoint.sh
@@ -16,22 +16,24 @@ function wait_for_postgres () {
 
 function wait_for_mysql () {
 	# Check if MySQL is up and accepting connections.
-	HOSTNAME=$(python3 <<EOF
-try:
-    from urllib.parse import urlparse
-except ImportError:
-    from urlparse import urlparse
-o = urlparse('$DATABASE_URL')
-print(o.hostname)
-EOF
-)
-	until mysqladmin ping --host "$HOSTNAME" --silent; do
-		>&2 echo "MySQL is unavailable - sleeping"
-		sleep 1
-	done
-	>&2 echo "MySQL is up - continuing"
-}
+	HOSTNAME=$(python3 -c "from urllib.parse import urlparse; o = urlparse('$DATABASE_URL'); print(o.hostname);")
+	PORT=$(python3 -c "from urllib.parse import urlparse; o = urlparse('$DATABASE_URL'); print(o.port);")
 
+	if [[ $PORT  == "None" ]]
+	then
+		until mysqladmin ping --host "$HOSTNAME" --silent; do
+			>&2 echo "MySQL ($HOSTNAME) is unavailable - sleeping"
+			sleep 1
+		done
+		>&2 echo "MySQL is up - continuing"
+	else
+		until mysqladmin ping --host "$HOSTNAME" --port "$PORT" --silent; do
+			>&2 echo "MySQL ($HOSTNAME) is unavailable - sleeping"
+			sleep 1
+		done
+		>&2 echo "MySQL is up - continuing"
+	fi
+}
 
 function check_or_create () {
 	# Check if the path exists, if not, create the directory.


### PR DESCRIPTION
When using a mysql port, the container won't start because wait_for_mysql() is ignoring the port.

This is a quick and dirty fix proposition for it.