### PR TITLE
Update fulltext search engine to Xapian from Whoosh.

### DIFF
--- a/web/mailman-web/settings.py
+++ b/web/mailman-web/settings.py
@@ -315,13 +315,13 @@ COMPRESS_PRECOMPILERS = (
 #
 HAYSTACK_CONNECTIONS = {
     'default': {
-        'ENGINE': 'haystack.backends.whoosh_backend.WhooshEngine',
+        # 'ENGINE': 'haystack.backends.whoosh_backend.WhooshEngine',
         'PATH': "/opt/mailman-web-data/fulltext_index",
         # You can also use the Xapian engine, it's faster and more accurate,
         # but requires another library.
         # http://django-haystack.readthedocs.io/en/v2.4.1/installing_search_engines.html#xapian
         # Example configuration for Xapian:
-        #'ENGINE': 'xapian_backend.XapianEngine'
+        'ENGINE': 'xapian_backend.XapianEngine'
     },
 }
 


### PR DESCRIPTION
This is a major change and will change the fulltext search engine to Xapian, instead of Whoosh, which is useful for development only.
