### PR TITLE
Exim4 configuration - Drop MM3_LISTCHK, MM3_HOME

### DIFF
--- a/core/assets/exim/25_mm3_macros
+++ b/core/assets/exim/25_mm3_macros
@@ -4,12 +4,3 @@
 domainlist mm3_domains=MY_DOMAIN_NAME
 MM3_LMTP_HOST=172.19.199.2
 MM3_LMTP_PORT=8024
-MM3_HOME=/opt/mailman/core/var
-
-################################################################
-# The configuration below is boilerplate:
-# you should not need to change it.
-
-# The path to the list receipt (used as the required file when
-# matching list addresses)
-MM3_LISTCHK=MM3_HOME/lists/${local_part}.${domain}

--- a/core/assets/exim/455_mm3_router
+++ b/core/assets/exim/455_mm3_router
@@ -4,7 +4,6 @@
 mailman3_router:
   driver = accept
   domains = +mm3_domains
-  require_files = MM3_LISTCHK
   local_part_suffix_optional
   local_part_suffix = -admin : \
      -bounces   : -bounces+* : \


### PR DESCRIPTION
There is no need for Exim4 to check the list exists. This is correctly
handled at the LMTP level:
    LMTP error after DATA: 550 Requested action not taken:
    mailbox unavailable

Dropping the router `require_files` allows for dropping variables MM3_HOME
and MM3_LISTCHK, and simplifies the Exim4 configuration which doens't need
access to /opt/mailman/core/var anymore.