### PR TITLE
Include django-auth-ldap in mailman-web (#374)

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -12,7 +12,7 @@ COPY docker-entrypoint.sh /usr/local/bin/
 # rights for management script
 RUN set -ex \
 	&& apk add --no-cache --virtual .build-deps gcc libc-dev linux-headers \
-		postgresql-dev mariadb-dev python3-dev libffi-dev \
+		postgresql-dev mariadb-dev python3-dev libffi-dev openldap-dev \
 	&& apk add --no-cache --virtual .mailman-rundeps bash sassc \
 	   postgresql-client mysql-client py-mysqldb curl mailcap gettext \
 	   python3 py3-setuptools xapian-core xapian-bindings-python3 libffi \
@@ -28,6 +28,7 @@ RUN set -ex \
 		mysqlclient \
 		typing \
 		xapian-haystack \
+		django-auth-ldap \
 	&& apk del .build-deps \
 	&& addgroup -S mailman \
 	&& adduser -S -G mailman mailman \

--- a/web/Dockerfile.dev
+++ b/web/Dockerfile.dev
@@ -17,7 +17,7 @@ ARG CLIENT_REF
 # rights for management script
 RUN set -ex \
     && apk add --no-cache --virtual .build-deps gcc libc-dev linux-headers git \
-        postgresql-dev mariadb-dev python3-dev libffi-dev \
+        postgresql-dev mariadb-dev python3-dev libffi-dev openldap-dev \
     && apk add --no-cache --virtual .mailman-rundeps bash sassc \
       python3 py3-setuptools postgresql-client mysql-client py-mysqldb\
         curl mailcap xapian-core xapian-bindings-python3 libffi gettext \
@@ -31,6 +31,7 @@ RUN set -ex \
         dj-database-url \
         mysqlclient \
         xapian-haystack \
+        django-auth-ldap \
     && python3 -m pip install -U 'Django<3.0' \
     && python3 -m pip install -U \
        git+https://gitlab.com/mailman/django-mailman3@${DJ_MM3_REF} \


### PR DESCRIPTION
I've build tested both images and I could load the appropriate python packages from within python shell. I've not run this particular change in production.