### PR TITLE
Install python-memcached in Mailman Web

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -29,6 +29,7 @@ RUN set -ex \
 		typing \
 		xapian-haystack \
 		django-auth-ldap \
+		python-memcached \
 	&& apk del .build-deps \
 	&& addgroup -S mailman \
 	&& adduser -S -G mailman mailman \

--- a/web/Dockerfile.dev
+++ b/web/Dockerfile.dev
@@ -33,6 +33,7 @@ RUN set -ex \
         mysqlclient \
         xapian-haystack \
         django-auth-ldap \
+		python-memcached \
     && python3 -m pip install -U 'Django<3.0' \
     && python3 -m pip install -U \
        git+https://gitlab.com/mailman/django-mailman3@${DJ_MM3_REF} \


### PR DESCRIPTION
Installing `python-memcached` in the image allows users to enable memcached-based caching:

```python
CACHES = {
    'default': {
        'BACKEND': 'django.core.cache.backends.memcached.MemcachedCache',
        'LOCATION': 'memcached:11211',
    }
}
```