### PR TITLE
Gunicorn configurable

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -61,8 +61,7 @@ standard version of docker-compose.yaml from this repository.
 
 - `HYPERKITTY_URL`: Default value is `http://mailman-web:8000/hyperkitty`
 
-In case of a need for fine tuning of Gunicorn web-server (e.g. for raising of timeouts)
-`/opt/mailman/gunicorn-extra.cfg` file could be provided holding necessary parameters.
+In case of a need for fine tuning of REST API web-server that uses [Gunicorn](https://docs.gunicorn.org/en/stable/settings.html) (e.g. for raising of timeouts) `/opt/mailman/core/gunicorn-extra.cfg` file could be provided holding necessary configuration options.
 
 Running Mailman-Core
 ====================

--- a/core/README.md
+++ b/core/README.md
@@ -63,6 +63,16 @@ standard version of docker-compose.yaml from this repository.
 
 In case of a need for fine tuning of REST API web-server that uses [Gunicorn](https://docs.gunicorn.org/en/stable/settings.html) (e.g. for raising of timeouts) `/opt/mailman/core/gunicorn-extra.cfg` file could be provided holding necessary configuration options.
 
+Configuration file, [shipped with Mailman Core](https://gitlab.com/mailman/mailman/-/blob/master/src/mailman/config/gunicorn.cfg), is used by default.
+
+For example, to increase the default 30 sec timeout, which won't work for some API calls to highly populated lists, provide the following `gunicorn-extra.cfg` file:
+
+```
+[gunicorn]
+graceful_timeout = 30
+timeout = 300
+```
+
 Running Mailman-Core
 ====================
 
@@ -105,6 +115,7 @@ hostname: $MM_HOSTNAME
 port: $MAILMAN_REST_PORT
 admin_user: $MAILMAN_REST_USER
 admin_pass: $MAILMAN_REST_PASSWORD
+configuration: /etc/gunicorn.cfg
 
 [archiver.hyperkitty]
 class: mailman_hyperkitty.Archiver

--- a/core/README.md
+++ b/core/README.md
@@ -61,6 +61,9 @@ standard version of docker-compose.yaml from this repository.
 
 - `HYPERKITTY_URL`: Default value is `http://mailman-web:8000/hyperkitty`
 
+In case of a need for fine tuning of Gunicorn web-server (e.g. for raising of timeouts)
+`/opt/mailman/gunicorn-extra.cfg` file could be provided holding necessary parameters.
+
 Running Mailman-Core
 ====================
 

--- a/core/docker-entrypoint.sh
+++ b/core/docker-entrypoint.sh
@@ -133,7 +133,8 @@ configuration: /etc/mailman-hyperkitty.cfg
 EOF
 
 # Generate a basic gunicorn.cfg.
-echo '[gunicorn]' > /etc/gunicorn.cfg
+SITE_DIR=$(python3 -c 'import site; print(site.getsitepackages()[0])')
+cp "${SITE_DIR}/mailman/config/gunicorn.cfg" /etc/gunicorn.cfg
 
 # Generate a basic configuration to use exim
 cat > /tmp/exim-mailman.cfg <<EOF

--- a/core/docker-entrypoint.sh
+++ b/core/docker-entrypoint.sh
@@ -192,7 +192,7 @@ fi
 
 if [[ -e /opt/mailman/gunicorn-extra.cfg ]]
 then
-       echo "Found configuration file at /opt/mailman/gunicorn-extra.cfg"
+       echo "Found [webserver] configuration file at /opt/mailman/gunicorn-extra.cfg"
        cat /opt/mailman/gunicorn-extra.cfg >> /etc/gunicorn.cfg
 fi
 

--- a/core/docker-entrypoint.sh
+++ b/core/docker-entrypoint.sh
@@ -123,6 +123,7 @@ hostname: $MM_HOSTNAME
 port: $MAILMAN_REST_PORT
 admin_user: $MAILMAN_REST_USER
 admin_pass: $MAILMAN_REST_PASSWORD
+configuration: /etc/gunicorn.cfg
 
 [archiver.hyperkitty]
 class: mailman_hyperkitty.Archiver
@@ -130,6 +131,9 @@ enable: yes
 configuration: /etc/mailman-hyperkitty.cfg
 
 EOF
+
+# Generate a basic gunicorn.cfg.
+echo '[gunicorn]' > /etc/gunicorn.cfg
 
 # Generate a basic configuration to use exim
 cat > /tmp/exim-mailman.cfg <<EOF
@@ -186,6 +190,11 @@ then
 	cat /opt/mailman/mailman-extra.cfg >> /etc/mailman.cfg
 fi
 
+if [[ -e /opt/mailman/gunicorn-extra.cfg ]]
+then
+       echo "Found configuration file at /opt/mailman/gunicorn-extra.cfg"
+       cat /opt/mailman/gunicorn-extra.cfg >> /etc/gunicorn.cfg
+fi
 
 if [[ ! -v HYPERKITTY_API_KEY ]]; then
 	echo "HYPERKITTY_API_KEY not defined, please set this environment variable..."

--- a/core/docker-entrypoint.sh
+++ b/core/docker-entrypoint.sh
@@ -194,7 +194,7 @@ fi
 if [[ -e /opt/mailman/gunicorn-extra.cfg ]]
 then
        echo "Found [webserver] configuration file at /opt/mailman/gunicorn-extra.cfg"
-       cat /opt/mailman/gunicorn-extra.cfg >> /etc/gunicorn.cfg
+       cat /opt/mailman/gunicorn-extra.cfg > /etc/gunicorn.cfg
 fi
 
 if [[ ! -v HYPERKITTY_API_KEY ]]; then


### PR DESCRIPTION
This change provides an easy way to add extra parameters to Gunicorn web-server configuration.
They might be necessary to overcome long delays of API calls to highly populated lists (see https://github.com/maxking/docker-mailman/issues/387 ).