### PR TITLE
Include dnspython dependency in quotes

### DIFF
--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -17,7 +17,7 @@ RUN apk update \
                    mailman==3.3.1 \
                    mailman-hyperkitty==1.1.0 \
                    pymysql \
-		   dnspython<2.0 \
+		   'dnspython<2.0' \
     && apk del build-deps \
     && adduser -S mailman
 


### PR DESCRIPTION
Not using quotes mean the shell considers `<` as the redirection
from a file called 2.0

Fixes #399