### PR TITLE
Bump PostgreSQL to version 12

### DIFF
--- a/docker-compose-postorius.yaml
+++ b/docker-compose-postorius.yaml
@@ -48,7 +48,7 @@ services:
       POSTGRES_USER: mailman
       POSTGRES_PASSWORD: mailmanpass
     restart: always
-    image: postgres:9.6-alpine
+    image: postgres:12-alpine
     volumes:
     - /opt/mailman/database:/var/lib/postgresql/data
     networks:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -45,7 +45,7 @@ services:
       POSTGRES_DB: mailmandb
       POSTGRES_USER: mailman
       POSTGRES_PASSWORD: mailmanpass
-    image: postgres:9.6-alpine
+    image: postgres:12-alpine
     volumes:
     - /opt/mailman/database:/var/lib/postgresql/data
     networks:


### PR DESCRIPTION
This bumps PostgreSQL to version 12, which is the current LTS release. I just tested it in a recent Mailman 3 installation, works just fine.