### PR TITLE
Fix typo in uwsgi.ini

### DIFF
--- a/postorius/mailman-web/uwsgi.ini
+++ b/postorius/mailman-web/uwsgi.ini
@@ -11,7 +11,7 @@ wsgi-file = wsgi.py
 
 # Setup default number of processes and threads per process.
 master = true
-process = 4
+processes = 4
 
 # Drop privielges and don't run as root.
 uid = mailman


### PR DESCRIPTION
The option that controls the amount of workers in uwsgi is processes not process.
Now the container spawns four processes instead of one.

Fixes #368