### PR TITLE
Easy override for social logins

### DIFF
--- a/postorius/mailman-web/settings.py
+++ b/postorius/mailman-web/settings.py
@@ -65,7 +65,8 @@ MAILMAN_ARCHIVER_FROM = (os.environ.get('MAILMAN_HOST_IP', gethostbyname(os.envi
 
 # Application definition
 
-INSTALLED_APPS = [
+INSTALLED_APPS = []
+DEFAULT_APPS = [
     'postorius',
     'django_mailman3',
     # Uncomment the next line to enable the admin:
@@ -82,6 +83,8 @@ INSTALLED_APPS = [
     'allauth',
     'allauth.account',
     'allauth.socialaccount',
+]
+MAILMAN_WEB_SOCIAL_AUTH = [
     'django_mailman3.lib.auth.fedora',
     'allauth.socialaccount.providers.openid',
     'allauth.socialaccount.providers.github',
@@ -344,3 +347,7 @@ try:
     from settings_local import *
 except ImportError:
     pass
+
+# Compatibility for older installs that override INSTALLED_APPS
+if not INSTALLED_APPS:
+    INSTALLED_APPS = DEFAULT_APPS + MAILMAN_WEB_SOCIAL_AUTH

--- a/web/README.md
+++ b/web/README.md
@@ -71,6 +71,14 @@ change them unless you know what you want.
   `http://mailman-web:8000` by default so that Core can fetch templates from
   Web.
 
+- `MAILMAN_WEB_SOCIAL_AUTH`: This is a list of Social login providers.
+  It contains a default set of providers. Override it if you want to remove
+  or disable social login entierly.
+  If `INSTALLED_APPS` is overridden `MAILMAN_WEB_SOCIAL_AUTH` is not used and
+  you must specify any social login provider in `INSTALLED_APPS` instead.
+  See [settings.py](mailman-web/settings.py) for implementation details.
+
+
 Running
 =======
 

--- a/web/mailman-web/settings.py
+++ b/web/mailman-web/settings.py
@@ -99,16 +99,6 @@ MAILMAN_WEB_SOCIAL_AUTH = [
     'allauth.socialaccount.providers.google',
 ]
 
-# Optionally include paintstore, if it was installed with Hyperkitty.
-# TODO: Remove this after a new version of Hyperkitty is released and
-# neither the stable nor the rolling version needs it.
-try:
-    import paintstore
-    DEFAULT_APPS.append('paintstore')
-except ImportError:
-    pass
-
-
 MIDDLEWARE = (
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',

--- a/web/mailman-web/settings.py
+++ b/web/mailman-web/settings.py
@@ -66,7 +66,8 @@ MAILMAN_ARCHIVER_FROM = (os.environ.get('MAILMAN_HOST_IP', gethostbyname(os.envi
 
 # Application definition
 
-INSTALLED_APPS = [
+INSTALLED_APPS = []
+DEFAULT_APPS = [
     'hyperkitty',
     'postorius',
     'django_mailman3',
@@ -89,6 +90,8 @@ INSTALLED_APPS = [
     'allauth',
     'allauth.account',
     'allauth.socialaccount',
+]
+MAILMAN_WEB_SOCIAL_AUTH = [
     'django_mailman3.lib.auth.fedora',
     'allauth.socialaccount.providers.openid',
     'allauth.socialaccount.providers.github',
@@ -101,7 +104,7 @@ INSTALLED_APPS = [
 # neither the stable nor the rolling version needs it.
 try:
     import paintstore
-    INSTALLED_APPS.append('paintstore')
+    DEFAULT_APPS.append('paintstore')
 except ImportError:
     pass
 
@@ -412,3 +415,7 @@ try:
     from settings_local import *
 except ImportError:
     pass
+
+# Compatibility for older installs that override INSTALLED_APPS
+if not INSTALLED_APPS:
+    INSTALLED_APPS = DEFAULT_APPS + MAILMAN_WEB_SOCIAL_AUTH


### PR DESCRIPTION
The `MAILMAN_WEB_SOCIAL_AUTH` list contains a default set of social
login provides. This was previously included in `INSTALLED_APPS`.

Separating it to it's own list makes it easier to disable or otherwise
override which social login providers are enabled without the need to
modify `INSTALLED_APPS`.

Older installations where `INSTALLED_APPS` were overridden continues to
work. The `MAILMAN_WEB_SOCIAL_AUTH` is ignored for those and
`INSTALLED_APPS` is used as is.

Solves: #305