### PR TITLE
WIP:Fixing ALLOWED_HOSTS

### DIFF
--- a/postorius/mailman-web/settings.py
+++ b/postorius/mailman-web/settings.py
@@ -52,8 +52,7 @@ ALLOWED_HOSTS = [
     # "lists.your-domain.org",
     # Add here all production URLs you may have.
     "mailman-web",
-    gethostbyname("mailman-web"),
-    os.environ.get('SERVE_FROM_DOMAIN'),
+    os.environ.get('SERVE_FROM_DOMAIN', gethostbyname("mailman-web")),
     os.environ.get('DJANGO_ALLOWED_HOSTS'),
 ]
 

--- a/web/mailman-web/settings.py
+++ b/web/mailman-web/settings.py
@@ -52,8 +52,7 @@ ALLOWED_HOSTS = [
     # "lists.your-domain.org",
     # Add here all production URLs you may have.
     "mailman-web",
-    gethostbyname("mailman-web"),
-    os.environ.get('SERVE_FROM_DOMAIN'),
+    os.environ.get('SERVE_FROM_DOMAIN', gethostbyname("mailman-web")),
     os.environ.get('DJANGO_ALLOWED_HOSTS'),
 ]
 


### PR DESCRIPTION
Hey,

After the [recent PR](https://github.com/maxking/docker-mailman/pull/441) has merged, I've discovered that `mailman-web` container won't start in case of mailman-web domain name is not resolvable:

```
                               List of databases
   Name    |  Owner  | Encoding |  Collate   |   Ctype    |  Access privileges
-----------+---------+----------+------------+------------+---------------------
 mailmandb | mailman | UTF8     | en_US.utf8 | en_US.utf8 |
 postgres  | mailman | UTF8     | en_US.utf8 | en_US.utf8 |
 template0 | mailman | UTF8     | en_US.utf8 | en_US.utf8 | =c/mailman         +
           |         |          |            |            | mailman=CTc/mailman
 template1 | mailman | UTF8     | en_US.utf8 | en_US.utf8 | =c/mailman         +
           |         |          |            |            | mailman=CTc/mailman
(4 rows)

Postgres is up - continuing
Copying settings_local.py ...
Traceback (most recent call last):
  File "manage.py", line 10, in <module>
    execute_from_command_line(sys.argv)
  File "/usr/lib/python3.8/site-packages/django/core/management/__init__.py", line 381, in execute_from_command_line
    utility.execute()
  File "/usr/lib/python3.8/site-packages/django/core/management/__init__.py", line 325, in execute
    settings.INSTALLED_APPS
  File "/usr/lib/python3.8/site-packages/django/conf/__init__.py", line 79, in __getattr__
    self._setup(name)
  File "/usr/lib/python3.8/site-packages/django/conf/__init__.py", line 66, in _setup
    self._wrapped = Settings(settings_module)
  File "/usr/lib/python3.8/site-packages/django/conf/__init__.py", line 157, in __init__
    mod = importlib.import_module(self.SETTINGS_MODULE)
  File "/usr/lib/python3.8/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
  File "<frozen importlib._bootstrap>", line 991, in _find_and_load
  File "<frozen importlib._bootstrap>", line 975, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 671, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 783, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/opt/mailman-web/settings.py", line 55, in <module>
    gethostbyname("mailman-web"),
socket.gaierror: [Errno -2] Name does not resolve
```

This can be quite a valid use case when one provides `SERVE_FROM_DOMAIN` environment variable.

This change is to fix this issue.