### PR TITLE
Adding django-utils-six for xapian

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -31,6 +31,7 @@ RUN set -ex \
 		django-auth-ldap \
 		python-memcached \
 		diskcache \
+		django-utils-six \
 	&& apk del .build-deps \
 	&& addgroup -S mailman \
 	&& adduser -S -G mailman mailman \

--- a/web/Dockerfile.dev
+++ b/web/Dockerfile.dev
@@ -35,6 +35,7 @@ RUN set -ex \
         django-auth-ldap \
 		python-memcached \
         diskcache \
+        django-utils-six \
     && python3 -m pip install -U 'Django<3.1' \
     && python3 -m pip install -U \
        git+https://gitlab.com/mailman/django-mailman3@${DJ_MM3_REF} \


### PR DESCRIPTION
As after https://github.com/maxking/docker-mailman/pull/467 we have switched to django 3, we need to install `django-utils-six` to make xapian search backend work (see [this thread](https://lists.mailman3.org/archives/list/mailman-users@mailman3.org/thread/SXJ2FQ6F7XRSVWJ7TELR5A5F2O6C2KAZ/#TWHZAY4WD7T2GYWPXBP5HELDHCVNUDKW)).