### PR TITLE
Pin psycopg2<2.9 for supporting Django 2.2.

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -23,7 +23,7 @@ RUN set -ex \
 		django-mailman3==1.3.5 \
 		whoosh \
 		uwsgi \
-		psycopg2 \
+		'psycopg2<2.9' \
 		dj-database-url \
 		mysqlclient \
 		typing \

--- a/web/Dockerfile.dev
+++ b/web/Dockerfile.dev
@@ -28,7 +28,7 @@ RUN set -ex \
         git+https://gitlab.com/mailman/hyperkitty@${HYPERKITTY_REF} \
         whoosh \
         uwsgi \
-        psycopg2 \
+        'psycopg2<2.9' \
         dj-database-url \
         mysqlclient \
         xapian-haystack \


### PR DESCRIPTION
https://github.com/psycopg/psycopg2/issues/1293