### PR TITLE
Added added code needed to build for amd64, arm32 and arm64 processors

### DIFF
--- a/.travis/deploy.sh
+++ b/.travis/deploy.sh
@@ -14,9 +14,12 @@ deploy() {
 	docker tag maxking/postorius:rolling "$URL/maxking/postorius:$TAG"
 	# Login to the registry and push.
 	docker login -u $USER -p $PASSWORD $URL
-	docker push "$URL/maxking/mailman-web:$TAG"
-	docker push "$URL/maxking/mailman-core:$TAG"
-	docker push "$URL/maxking/postorius:$TAG"
+	#docker push "$URL/maxking/mailman-web:$TAG"
+	#docker push "$URL/maxking/mailman-core:$TAG"
+	#docker push "$URL/maxking/postorius:$TAG"	
+	docker manifest push "$URL/maxking/mailman-web:$TAG"
+    docker manifest push "$URL/maxking/mailman-core:$TAG"
+    docker manifest push "$URL/maxking/postorius:$TAG"
 }
 
 if [ ! "$BRANCH" = "master" ] && [ "$PULL_REQUEST" ]; then

--- a/build.sh
+++ b/build.sh
@@ -25,16 +25,17 @@ if [ "$EVENT_TYPE" = "cron" ]  || [ "$DEV" = "true" ]; then
     MM3_HK_REF=$(python get_latest_ref.py mailman/mailman-hyperkitty)
 
     # Build the mailman-core image.
-    $DOCKER build -f core/Dockerfile.dev \
+    $DOCKER buildx build -f core/Dockerfile.dev \
             --build-arg CORE_REF=$CORE_REF \
             --build-arg MM3_HK_REF=$MM3_HK_REF \
             --label version.core="$CORE_REF" \
             --label version.mm3-hk="$MM3_HK_REF" \
             --label version.git_commit="$COMMIT_ID" \
-            -t maxking/mailman-core:rolling core/
+            --platform linux/arm/v7,linux/arm64/v8,linux/amd64
+	        --tag maxking/mailman-core:rolling core/
 
     # Build the mailman-web image.
-    $DOCKER build -f web/Dockerfile.dev \
+    $DOCKER buildx build -f web/Dockerfile.dev \
             --label version.git_commit="$COMMIT_ID" \
             --label version.postorius="$POSTORIUS_REF" \
             --label version.hyperkitty="$HYPERKITTY_REF" \
@@ -44,9 +45,10 @@ if [ "$EVENT_TYPE" = "cron" ]  || [ "$DEV" = "true" ]; then
             --build-arg CLIENT_REF=$CLIENT_REF \
             --build-arg HYPERKITTY_REF=$HYPERKITTY_REF \
             --build-arg DJ_MM3_REF=$DJ_MM3_REF \
-            -t maxking/mailman-web:rolling web/
+			--platform linux/arm/v7,linux/arm64/v8,linux/amd64
+	        --tag maxking/mailman-web:rolling web/
 
-    $DOCKER build -f postorius/Dockerfile.dev\
+    $DOCKER buildx build -f postorius/Dockerfile.dev\
 			--label version.git_commit="$COMMIT_ID"\
             --label version.postorius="$POSTORIUS_REF" \
             --label version.client="$CLIENT_REF" \
@@ -54,10 +56,17 @@ if [ "$EVENT_TYPE" = "cron" ]  || [ "$DEV" = "true" ]; then
             --build-arg POSTORIUS_REF=$POSTORIUS_REF \
             --build-arg CLIENT_REF=$CLIENT_REF \
             --build-arg DJ_MM3_REF=$DJ_MM3_REF \
-			-t maxking/postorius:rolling postorius/
+			--platform linux/arm/v7,linux/arm64/v8,linux/amd64
+	        --tag maxking/postorius:rolling postorius/
 else
     # Do the normal building process.
-    $DOCKER build -t maxking/mailman-core:rolling core/
-    $DOCKER build -t maxking/mailman-web:rolling web/
-    $DOCKER build -t maxking/postorius:rolling postorius/
+    $DOCKER buildx build \
+	  --platform linux/arm/v7,linux/arm64/v8,linux/amd64
+	  --tag maxking/mailman-core:rolling core/
+    $DOCKER buildx build \
+	  --platform linux/arm/v7,linux/arm64/v8,linux/amd64
+	  --tag maxking/mailman-web:rolling web/
+    $DOCKER buildx build \
+	  --platform linux/arm/v7,linux/arm64/v8,linux/amd64
+	  --tag maxking/postorius:rolling postorius/
 fi

--- a/build.sh
+++ b/build.sh
@@ -71,12 +71,12 @@ else
 		$DOCKER build \
 		--build-arg ARCH=$arch \
 		-t maxking/mailman-core:rolling-$arch core/
-		$DOCKER push maxking/mailman-core:rolling-$arch core
+		$DOCKER push maxking/mailman-core:rolling-$arch
 		
 		$DOCKER build \
 		--build-arg ARCH=$arch \
 		-t maxking/mailman-web:rolling-$arch web/
-		$DOCKER push maxking/mailman-web:rolling-$arch web
+		$DOCKER push maxking/mailman-web:rolling-$arch
 		
 		$DOCKER build \
 		--build-arg ARCH=$arch \

--- a/build.sh
+++ b/build.sh
@@ -35,7 +35,7 @@ if [ "$EVENT_TYPE" = "cron" ]  || [ "$DEV" = "true" ]; then
             --label version.mm3-hk="$MM3_HK_REF" \
             --label version.git_commit="$COMMIT_ID" \
 	        -t maxking/mailman-core:rolling-$arch core/
-		$DOCKER push maxking/mailman-core:rolling-$arch core
+		$DOCKER push maxking/mailman-core:rolling-$arch
 
 		# Build the mailman-web image.
 		$DOCKER build -f web/Dockerfile.dev \
@@ -50,7 +50,7 @@ if [ "$EVENT_TYPE" = "cron" ]  || [ "$DEV" = "true" ]; then
             --build-arg HYPERKITTY_REF=$HYPERKITTY_REF \
             --build-arg DJ_MM3_REF=$DJ_MM3_REF \
 	        -t maxking/mailman-web:rolling-$arch web/
-		$DOCKER push maxking/mailman-web:rolling-$arch web
+		$DOCKER push maxking/mailman-web:rolling-$arch
 
 		$DOCKER build -f postorius/Dockerfile.dev\
 	        --build-arg ARCH=$arch \
@@ -62,7 +62,7 @@ if [ "$EVENT_TYPE" = "cron" ]  || [ "$DEV" = "true" ]; then
             --build-arg CLIENT_REF=$CLIENT_REF \
             --build-arg DJ_MM3_REF=$DJ_MM3_REF \
 	        -t maxking/postorius:rolling-$arch postorius/
-		$DOCKER push maxking/postorius:rolling-$arch postorius
+		$DOCKER push maxking/postorius:rolling-$arch
 	done
 else
 	for arch in amd64 arm32v7 arm64v8
@@ -81,7 +81,7 @@ else
 		$DOCKER build \
 		--build-arg ARCH=$arch \
 		-t maxking/postorius:rolling-$arch postorius/
-		$DOCKER push maxking/postorius:rolling-$arch postorius
+		$DOCKER push maxking/postorius:rolling-$arch
 	done
 fi
 

--- a/build.sh
+++ b/build.sh
@@ -35,7 +35,6 @@ if [ "$EVENT_TYPE" = "cron" ]  || [ "$DEV" = "true" ]; then
             --label version.mm3-hk="$MM3_HK_REF" \
             --label version.git_commit="$COMMIT_ID" \
 	        -t maxking/mailman-core:rolling-$arch core/
-		$DOCKER push maxking/mailman-core:rolling-$arch
 
 		# Build the mailman-web image.
 		$DOCKER build -f web/Dockerfile.dev \
@@ -50,7 +49,6 @@ if [ "$EVENT_TYPE" = "cron" ]  || [ "$DEV" = "true" ]; then
             --build-arg HYPERKITTY_REF=$HYPERKITTY_REF \
             --build-arg DJ_MM3_REF=$DJ_MM3_REF \
 	        -t maxking/mailman-web:rolling-$arch web/
-		$DOCKER push maxking/mailman-web:rolling-$arch
 
 		$DOCKER build -f postorius/Dockerfile.dev\
 	        --build-arg ARCH=$arch \
@@ -62,7 +60,6 @@ if [ "$EVENT_TYPE" = "cron" ]  || [ "$DEV" = "true" ]; then
             --build-arg CLIENT_REF=$CLIENT_REF \
             --build-arg DJ_MM3_REF=$DJ_MM3_REF \
 	        -t maxking/postorius:rolling-$arch postorius/
-		$DOCKER push maxking/postorius:rolling-$arch
 	done
 else
 	for arch in amd64 arm32v7 arm64v8
@@ -71,17 +68,14 @@ else
 		$DOCKER build \
 		--build-arg ARCH=$arch \
 		-t maxking/mailman-core:rolling-$arch core/
-		$DOCKER push maxking/mailman-core:rolling-$arch
 		
 		$DOCKER build \
 		--build-arg ARCH=$arch \
 		-t maxking/mailman-web:rolling-$arch web/
-		$DOCKER push maxking/mailman-web:rolling-$arch
 		
 		$DOCKER build \
 		--build-arg ARCH=$arch \
 		-t maxking/postorius:rolling-$arch postorius/
-		$DOCKER push maxking/postorius:rolling-$arch
 	done
 fi
 
@@ -91,20 +85,14 @@ docker manifest create \
 	--amend maxking/mailman-core:rolling-arm32v7 \
 	--amend maxking/mailman-core:rolling-arm64v8
 	
-docker manifest push maxking/mailman-core:rolling
-
 docker manifest create \
 	maxking/mailman-web:rolling \
 	--amend maxking/mailman-web:rolling-amd64 \
 	--amend maxking/mailman-web:rolling-arm32v7 \
 	--amend maxking/mailman-web:rolling-arm64v8
-	
-docker manifest push maxking/mailman-web:rolling
 
 docker manifest create \
 	maxking/postorius:rolling \
 	--amend maxking/postorius:rolling-amd64 \
 	--amend maxking/postorius:rolling-arm32v7 \
 	--amend maxking/postorius:rolling-arm64v8
-	
-docker manifest push maxking/postorius:rolling

--- a/build.sh
+++ b/build.sh
@@ -24,18 +24,21 @@ if [ "$EVENT_TYPE" = "cron" ]  || [ "$DEV" = "true" ]; then
     DJ_MM3_REF=$(python get_latest_ref.py mailman/django-mailman3)
     MM3_HK_REF=$(python get_latest_ref.py mailman/mailman-hyperkitty)
 
-    # Build the mailman-core image.
-    $DOCKER buildx build -f core/Dockerfile.dev \
+	for value in amd64 arm32v7 arm64v8
+	do
+		# Build the mailman-core image.
+		$DOCKER build -f core/Dockerfile.dev \
+	        --build-arg ARCH=$value \
             --build-arg CORE_REF=$CORE_REF \
             --build-arg MM3_HK_REF=$MM3_HK_REF \
             --label version.core="$CORE_REF" \
             --label version.mm3-hk="$MM3_HK_REF" \
             --label version.git_commit="$COMMIT_ID" \
-            --platform linux/arm/v7,linux/arm64/v8,linux/amd64
-	        --tag maxking/mailman-core:rolling core/
+	        -t maxking/mailman-core:rolling-$value core/
 
-    # Build the mailman-web image.
-    $DOCKER buildx build -f web/Dockerfile.dev \
+		# Build the mailman-web image.
+		$DOCKER build -f web/Dockerfile.dev \
+	        --build-arg ARCH=$value \
             --label version.git_commit="$COMMIT_ID" \
             --label version.postorius="$POSTORIUS_REF" \
             --label version.hyperkitty="$HYPERKITTY_REF" \
@@ -45,10 +48,10 @@ if [ "$EVENT_TYPE" = "cron" ]  || [ "$DEV" = "true" ]; then
             --build-arg CLIENT_REF=$CLIENT_REF \
             --build-arg HYPERKITTY_REF=$HYPERKITTY_REF \
             --build-arg DJ_MM3_REF=$DJ_MM3_REF \
-			--platform linux/arm/v7,linux/arm64/v8,linux/amd64
-	        --tag maxking/mailman-web:rolling web/
+	        -t maxking/mailman-web:rolling-$value web/
 
-    $DOCKER buildx build -f postorius/Dockerfile.dev\
+		$DOCKER build -f postorius/Dockerfile.dev\
+	        --build-arg ARCH=$value \
 			--label version.git_commit="$COMMIT_ID"\
             --label version.postorius="$POSTORIUS_REF" \
             --label version.client="$CLIENT_REF" \
@@ -56,17 +59,38 @@ if [ "$EVENT_TYPE" = "cron" ]  || [ "$DEV" = "true" ]; then
             --build-arg POSTORIUS_REF=$POSTORIUS_REF \
             --build-arg CLIENT_REF=$CLIENT_REF \
             --build-arg DJ_MM3_REF=$DJ_MM3_REF \
-			--platform linux/arm/v7,linux/arm64/v8,linux/amd64
-	        --tag maxking/postorius:rolling postorius/
+	        -t maxking/postorius:rolling-$value postorius/
+	done
 else
-    # Do the normal building process.
-    $DOCKER buildx build \
-	  --platform linux/arm/v7,linux/arm64/v8,linux/amd64
-	  --tag maxking/mailman-core:rolling core/
-    $DOCKER buildx build \
-	  --platform linux/arm/v7,linux/arm64/v8,linux/amd64
-	  --tag maxking/mailman-web:rolling web/
-    $DOCKER buildx build \
-	  --platform linux/arm/v7,linux/arm64/v8,linux/amd64
-	  --tag maxking/postorius:rolling postorius/
+	for value in amd64 arm32v7 arm64v8
+	do
+		# Do the normal building process.
+		$DOCKER build \
+		--build-arg ARCH=$value \
+		-t maxking/mailman-core:rolling-$value core/
+		$DOCKER build \
+		--build-arg ARCH=$value \
+		-t maxking/mailman-web:rolling-$value web/
+		$DOCKER build \
+		--build-arg ARCH=$value \
+		-t maxking/postorius:rolling-$value postorius/
+	done
 fi
+
+docker manifest create \
+	maxking/mailman-core:rolling \
+	--amend maxking/mailman-core:rolling-amd64 \
+	--amend maxking/mailman-core:rolling-arm32v7 \
+	--amend maxking/mailman-core:rolling-arm64v8
+
+docker manifest create \
+	maxking/mailman-web:rolling \
+	--amend maxking/mailman-web:rolling-amd64 \
+	--amend maxking/mailman-web:rolling-arm32v7 \
+	--amend maxking/mailman-web:rolling-arm64v8
+
+docker manifest create \
+	maxking/postorius:rolling \
+	--amend maxking/postorius:rolling-amd64 \
+	--amend maxking/postorius:rolling-arm32v7 \
+	--amend maxking/postorius:rolling-arm64v8

--- a/build.sh
+++ b/build.sh
@@ -35,6 +35,7 @@ if [ "$EVENT_TYPE" = "cron" ]  || [ "$DEV" = "true" ]; then
             --label version.mm3-hk="$MM3_HK_REF" \
             --label version.git_commit="$COMMIT_ID" \
 	        -t maxking/mailman-core:rolling-$arch core/
+		$DOCKER push maxking/mailman-core:rolling-$arch core
 
 		# Build the mailman-web image.
 		$DOCKER build -f web/Dockerfile.dev \
@@ -49,6 +50,7 @@ if [ "$EVENT_TYPE" = "cron" ]  || [ "$DEV" = "true" ]; then
             --build-arg HYPERKITTY_REF=$HYPERKITTY_REF \
             --build-arg DJ_MM3_REF=$DJ_MM3_REF \
 	        -t maxking/mailman-web:rolling-$arch web/
+		$DOCKER push maxking/mailman-web:rolling-$arch web
 
 		$DOCKER build -f postorius/Dockerfile.dev\
 	        --build-arg ARCH=$arch \
@@ -60,6 +62,7 @@ if [ "$EVENT_TYPE" = "cron" ]  || [ "$DEV" = "true" ]; then
             --build-arg CLIENT_REF=$CLIENT_REF \
             --build-arg DJ_MM3_REF=$DJ_MM3_REF \
 	        -t maxking/postorius:rolling-$arch postorius/
+		$DOCKER push maxking/postorius:rolling-$arch postorius
 	done
 else
 	for arch in amd64 arm32v7 arm64v8
@@ -68,12 +71,17 @@ else
 		$DOCKER build \
 		--build-arg ARCH=$arch \
 		-t maxking/mailman-core:rolling-$arch core/
+		$DOCKER push maxking/mailman-core:rolling-$arch core
+		
 		$DOCKER build \
 		--build-arg ARCH=$arch \
 		-t maxking/mailman-web:rolling-$arch web/
+		$DOCKER push maxking/mailman-web:rolling-$arch web
+		
 		$DOCKER build \
 		--build-arg ARCH=$arch \
 		-t maxking/postorius:rolling-$arch postorius/
+		$DOCKER push maxking/postorius:rolling-$arch postorius
 	done
 fi
 
@@ -82,15 +90,21 @@ docker manifest create \
 	--amend maxking/mailman-core:rolling-amd64 \
 	--amend maxking/mailman-core:rolling-arm32v7 \
 	--amend maxking/mailman-core:rolling-arm64v8
+	
+docker manifest push maxking/mailman-core:rolling
 
 docker manifest create \
 	maxking/mailman-web:rolling \
 	--amend maxking/mailman-web:rolling-amd64 \
 	--amend maxking/mailman-web:rolling-arm32v7 \
 	--amend maxking/mailman-web:rolling-arm64v8
+	
+docker manifest push maxking/mailman-web:rolling
 
 docker manifest create \
 	maxking/postorius:rolling \
 	--amend maxking/postorius:rolling-amd64 \
 	--amend maxking/postorius:rolling-arm32v7 \
 	--amend maxking/postorius:rolling-arm64v8
+	
+docker manifest push maxking/postorius:rolling

--- a/build.sh
+++ b/build.sh
@@ -24,21 +24,21 @@ if [ "$EVENT_TYPE" = "cron" ]  || [ "$DEV" = "true" ]; then
     DJ_MM3_REF=$(python get_latest_ref.py mailman/django-mailman3)
     MM3_HK_REF=$(python get_latest_ref.py mailman/mailman-hyperkitty)
 
-	for value in amd64 arm32v7 arm64v8
+	for arch in amd64 arm32v7 arm64v8
 	do
 		# Build the mailman-core image.
 		$DOCKER build -f core/Dockerfile.dev \
-	        --build-arg ARCH=$value \
+	        --build-arg ARCH=$arch \
             --build-arg CORE_REF=$CORE_REF \
             --build-arg MM3_HK_REF=$MM3_HK_REF \
             --label version.core="$CORE_REF" \
             --label version.mm3-hk="$MM3_HK_REF" \
             --label version.git_commit="$COMMIT_ID" \
-	        -t maxking/mailman-core:rolling-$value core/
+	        -t maxking/mailman-core:rolling-$arch core/
 
 		# Build the mailman-web image.
 		$DOCKER build -f web/Dockerfile.dev \
-	        --build-arg ARCH=$value \
+	        --build-arg ARCH=$arch \
             --label version.git_commit="$COMMIT_ID" \
             --label version.postorius="$POSTORIUS_REF" \
             --label version.hyperkitty="$HYPERKITTY_REF" \
@@ -48,10 +48,10 @@ if [ "$EVENT_TYPE" = "cron" ]  || [ "$DEV" = "true" ]; then
             --build-arg CLIENT_REF=$CLIENT_REF \
             --build-arg HYPERKITTY_REF=$HYPERKITTY_REF \
             --build-arg DJ_MM3_REF=$DJ_MM3_REF \
-	        -t maxking/mailman-web:rolling-$value web/
+	        -t maxking/mailman-web:rolling-$arch web/
 
 		$DOCKER build -f postorius/Dockerfile.dev\
-	        --build-arg ARCH=$value \
+	        --build-arg ARCH=$arch \
 			--label version.git_commit="$COMMIT_ID"\
             --label version.postorius="$POSTORIUS_REF" \
             --label version.client="$CLIENT_REF" \
@@ -59,21 +59,21 @@ if [ "$EVENT_TYPE" = "cron" ]  || [ "$DEV" = "true" ]; then
             --build-arg POSTORIUS_REF=$POSTORIUS_REF \
             --build-arg CLIENT_REF=$CLIENT_REF \
             --build-arg DJ_MM3_REF=$DJ_MM3_REF \
-	        -t maxking/postorius:rolling-$value postorius/
+	        -t maxking/postorius:rolling-$arch postorius/
 	done
 else
-	for value in amd64 arm32v7 arm64v8
+	for arch in amd64 arm32v7 arm64v8
 	do
 		# Do the normal building process.
 		$DOCKER build \
-		--build-arg ARCH=$value \
-		-t maxking/mailman-core:rolling-$value core/
+		--build-arg ARCH=$arch \
+		-t maxking/mailman-core:rolling-$arch core/
 		$DOCKER build \
-		--build-arg ARCH=$value \
-		-t maxking/mailman-web:rolling-$value web/
+		--build-arg ARCH=$arch \
+		-t maxking/mailman-web:rolling-$arch web/
 		$DOCKER build \
-		--build-arg ARCH=$value \
-		-t maxking/postorius:rolling-$value postorius/
+		--build-arg ARCH=$arch \
+		-t maxking/postorius:rolling-$arch postorius/
 	done
 fi
 


### PR DESCRIPTION
I used [this blog post](https://www.docker.com/blog/multi-arch-build-and-images-the-simple-way/) to make changes to the build.sh that should allow multi arch builds to take place.  This should allow the project to build for AMD64 as normal as well as for ARM both 32 and 64 bit.

You will need to turn on experimental features to allow the manifest command to work properly.   I watched the build and it looks like the images are created successfully. The manifest should create the final image that will be pushed.