### PR TITLE
Bump the mailman-hyperkitty plugin to 1.2.0.

### DIFF
--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -15,7 +15,7 @@ RUN --mount=type=cache,target=/root/.cache \
         && python3 -m pip install psycopg2 \
                    gunicorn==19.9.0 \
                    mailman==3.3.5 \
-                   mailman-hyperkitty==1.1.0 \
+                   mailman-hyperkitty==1.2.0 \
                    pymysql \
                    'sqlalchemy<1.4.0' \
     && apk del build-deps \


### PR DESCRIPTION
This new version sends the api_key as an Authorization header instead of
a GET parameter, which fixes a security vulnerability. The change is needed
since Hyperkitty has been upgraded to 1.3.5.

As far as I can tell, this should fix #527; I have not directly tested the new images, 
but I have run `pip install mailman-hyperkitty==1.2.0` inside the container, and that was
enough to fix the archiver error.