### PR TITLE
Add lynx to the mailman core Docker image

### DIFF
--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -10,9 +10,8 @@ RUN --mount=type=cache,target=/root/.cache \
     && apk add --virtual build-deps gcc python3-dev musl-dev postgresql-dev \
        libffi-dev \
   # Mailman html to plaintext conversion uses lynx.
-    && apk add --no-cache lynx \
   # psutil needs linux-headers to compile on musl c library.
-    && apk add --no-cache bash su-exec postgresql-client mysql-client curl python3 py3-pip linux-headers py-cryptography mariadb-connector-c \
+    && apk add --no-cache bash su-exec postgresql-client mysql-client curl python3 py3-pip linux-headers py-cryptography mariadb-connector-c lynx \
     && python3 -m pip install -U pip setuptools wheel \
         && python3 -m pip install psycopg2 \
                    gunicorn==19.9.0 \

--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -9,6 +9,8 @@ RUN --mount=type=cache,target=/root/.cache \
     apk update \
     && apk add --virtual build-deps gcc python3-dev musl-dev postgresql-dev \
        libffi-dev \
+  # Mailman html to plaintext conversion uses lynx.
+    && apk add --no-cache lynx \
   # psutil needs linux-headers to compile on musl c library.
     && apk add --no-cache bash su-exec postgresql-client mysql-client curl python3 py3-pip linux-headers py-cryptography mariadb-connector-c \
     && python3 -m pip install -U pip setuptools wheel \


### PR DESCRIPTION
Mailman's convert_html_to_plaintext setting relies on the value of
html_to_plain_text_command which is by default set to:

  /usr/bin/lynx -dump $filename

This will fail on the current image because lynx is not installed.
Simply add lynx to the list of packages to install to correct this.
The file path for the lynx command installed via the Alpine package does
seem to be /usr/bin/lynx which means we don't need to update any
configuration to use this command. The defaults are sufficient.