### PR TITLE
Docker compose templating, updated postorius to work with latest, added quickstart example, postgres version bump

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,8 @@
+CORE_BIND_IP=127.0.0.1
+MAILMAN_WEB_BIND_IP=127.0.0.1
+DJANGO_RANDOM_SECRET_KEY=
+MAILMAN_WEB_LISTEN_DOMAIN=127.0.0.1
+MAILMAN_SUPERUSER_USERNAME=admin@mydomain.com
+MAILMAN_SUPERUSER_EMAIL=admin@mydomain.com
+#If DOCKER_VOLUME_PATH is set to a path data volumes will be mounted in directories under that path, otherwise if this is empty then they are created as normal docker volumes
+DOCKER_VOLUME_PATH=/opt/mailman/

--- a/README.md
+++ b/README.md
@@ -22,6 +22,30 @@ configurations that can be used to deploy the [Mailman 3 Suite][4].
 Please see [release page](https://github.com/maxking/docker-mailman/releases)
 for the releases and change log.
 
+## Quickstart for Testing
+
+It is highly recommended to read all these instructions before starting for production use.  If you are looking to quickly test a mailman setup here is a basic quickstart dev guide:
+
+* Clone this repo: `git clone https://github.com/maxking/docker-mailman.git` and change to that folder `cd docker-mailman`
+* Edit the `.env` file changing the following values:
+	- `MAILMAN_WEB_BIND_IP` set to the ip you want to access the container on (ie 192.168.1.50)
+	- `DJANGO_RANDOM_SECRET_KEY` any random string ie "Iax2iOB8lGZZf1235Lc4jkU3kw" used for signing cookies
+	- `MAILMAN_WEB_LISTEN_DOMAIN` to be the hostname (can be an ip) you plan to access the instance on (ie 192.168.1.50).
+	- `MAILMAN_ADMIN_USER` / `MAILMAN_ADMIN_EMAIL` to the initial superuser values you want, note you must have working SMTP to use this method, if you want to test without a mail server see the note at the end.
+	- `DOCKER_VOLUME_PATH` this can either be a path on the docker host (ie `/opt/mailman/`) or a volume name prefix (ie `mailman`) for volumes.  If you specify a host path these are stored directly on the host, if this is a prefix name these are normal docker volumes stored in the docker volume path.
+* Run `docker-compose -f .\docker-compose-postorius.yaml up` to create and bring up all 3 containers
+* Open a browser and go to http://MAILMAN_WEB_LISTEN_DOMAIN:8000/ you should see the mailing list welcome page.  Click login and click forgot password to email yourself the password link.
+* Follow the email instructions to set your password and login
+
+### Testing without an SMTP server
+If you want to test without a working SMTP server you can manually add a superuser with password and confirm the account:
+* Edit the .env FILE and comment out the variables `MAILMAN_ADMIN_USER` and `MAILMAN_ADMIN_EMAIL` before bringing the compose instance up for the first time
+* Run `docker exec -t -i mailman-web python3 manage.py createsuperuser` and create your admin user
+* bring the instance up with dockerr compose like above
+* Open the browser and try to login with the newly created user, you will get an error (it tries to email a confirmation)
+* run `docker exec -t -i mailman-web psql postgres://mailman:mailmanpass@database/mailmandb -c "UPDATE account_emailaddress SET verified=true WHERE id=1"`
+* You should now be able to login
+
 ## Release
 
 

--- a/docker-compose-postorius.yaml
+++ b/docker-compose-postorius.yaml
@@ -1,4 +1,4 @@
-version: '2'
+version: '3'
 
 services:
   mailman-core:
@@ -6,7 +6,7 @@ services:
     container_name: mailman-core
     hostname: mailman-core
     volumes:
-    - /opt/mailman/core:/opt/mailman/
+    - ${DOCKER_VOLUME_PATH}core:/opt/mailman/
     stop_grace_period: 30s
     links:
     - database:database
@@ -17,13 +17,13 @@ services:
     - DATABASE_TYPE=postgres
     - DATABASE_CLASS=mailman.database.postgresql.PostgreSQLDatabase
     ports:
-    - "127.0.0.1:8001:8001" # API
-    - "127.0.0.1:8024:8024" # LMTP - incoming emails
+    - "${CORE_BIND_IP-127.0.0.1}:8001:8001" # API
+    - "${CORE_BIND_IP-127.0.0.1}:8024:8024" # LMTP - incoming emails
     networks:
       mailman:
 
   mailman-web:
-    image: maxking/postorius:0.4
+    image: maxking/postorius:rolling
     container_name: mailman-web
     hostname: mailman-web
     depends_on:
@@ -32,15 +32,18 @@ services:
     - mailman-core:mailman-core
     - database:database
     volumes:
-    - /opt/mailman/web:/opt/mailman-web-data
+    - ${DOCKER_VOLUME_PATH}web:/opt/mailman-web-data
     environment:
     - DATABASE_TYPE=postgres
     - DATABASE_URL=postgres://mailman:mailmanpass@database/mailmandb
-    - SECRET_KEY=ksjdbaksdba
-    - UWSGI_STATIC_MAP=/static=/opt/mailman-web-data/static 
+    - SECRET_KEY=${DJANGO_RANDOM_SECRET_KEY:?DJANGO_RANDOM_SECRET_KEY must be specified}
+    - UWSGI_STATIC_MAP=/static=/opt/mailman-web-data/static
+    - MAILMAN_ADMIN_USER=${MAILMAN_SUPERUSER_USERNAME}
+    - MAILMAN_ADMIN_EMAIL=${MAILMAN_SUPERUSER_EMAIL}
+    - SERVE_FROM_DOMAIN=${MAILMAN_WEB_LISTEN_DOMAIN}
     ports:
-    - "127.0.0.1:8000:8000" # HTTP
-    - "127.0.0.1:8080:8080" # uwsgi
+    - "${MAILMAN_WEB_BIND_IP-127.0.0.1}:8000:8000" # HTTP
+    - "${MAILMAN_WEB_BIND_IP-127.0.0.1}:8080:8080" # uwsgi
     networks:
       mailman:
 
@@ -50,12 +53,17 @@ services:
       POSTGRES_USER: mailman
       POSTGRES_PASSWORD: mailmanpass
     restart: always
-    image: postgres:9.6-alpine
+    image: postgres:14-alpine
     volumes:
-    - /opt/mailman/database:/var/lib/postgresql/data
+    - ${DOCKER_VOLUME_PATH}database:/var/lib/postgresql/data
     networks:
       mailman:
 
+
+volumes:
+    core:
+    web:
+    database:
 networks:
    mailman:
     driver: bridge

--- a/postorius/Dockerfile
+++ b/postorius/Dockerfile
@@ -15,10 +15,9 @@ RUN --mount=type=cache,target=/root/.cache \
 		postgresql-dev mariadb-dev mariadb-connector-c python3-dev libffi-dev openldap-dev cargo rust \
 	&& apk add --no-cache --virtual .mailman-rundeps bash sassc \
 		postgresql-client mysql-client py3-mysqlclient curl mailcap gettext \
-		python3 py3-pip libffi libuuid pcre-dev py-cryptography \
+		python3 py3-pip libffi libuuid pcre-dev py-cryptography uwsgi uwsgi-logfile uwsgi-python \
 	&& python3 -m pip install -U 'Django<3.2' pip setuptools wheel \
 	&& python3 -m pip install postorius==1.3.6 \
-        uwsgi \
 		'psycopg2<2.9' \
 		dj-database-url \
 		mysqlclient \

--- a/postorius/docker-entrypoint.sh
+++ b/postorius/docker-entrypoint.sh
@@ -114,7 +114,7 @@ python3 manage.py collectstatic --noinput --clear --verbosity 0
 # Compile all the installed po files to mo.
 SITE_DIR=$(python3 -c 'import site; print(site.getsitepackages()[0])')
 echo "Compiling locale files in $SITE_DIR"
-cd $SITE_DIR && python3 /opt/mailman-web/manage.py compilemessages &&  cd -
+cd $SITE_DIR && python3 /opt/mailman-web/manage.py compilemessages &> /dev/null &&  cd -
 
 # Migrate all the data to the database if this is a new installation, otherwise
 # this command will upgrade the database.
@@ -127,7 +127,7 @@ if [[ -v MAILMAN_ADMIN_USER ]] && [[ -v MAILMAN_ADMIN_EMAIL ]];
 then
 	echo "Creating admin user $MAILMAN_ADMIN_USER ..."
 	python3 manage.py createsuperuser --noinput --username "$MAILMAN_ADMIN_USER"\
-		   --email "$MAILMAN_ADMIN_EMAIL" 2> /dev/null || \
+			--email "$MAILMAN_ADMIN_EMAIL" 2> /dev/null || \
 		echo "Superuser $MAILMAN_ADMIN_USER already exists"
 fi
 

--- a/postorius/mailman-web/uwsgi.ini
+++ b/postorius/mailman-web/uwsgi.ini
@@ -18,8 +18,11 @@ threads = 2
 uid = mailman
 gid = mailman
 
+plugins = python,logfile
+
 # Setup the request log.
 req-logger = file:/opt/mailman-web-data/logs/uwsgi.log
 
 # Last log and it logs the rest of the stuff.
 logger = file:/opt/mailman-web-data/logs/uwsgi-error.log
+


### PR DESCRIPTION
Added .env file for better template support of docker compose
Readme added a quickstart example for users looking to test
Postorius wouldn't run with the modern updates, mainly around uwsgi updates

This should hopefully make it easier for people to see what to change, and also adds support for normal docker volumes rather than host binds (if you clear the DOCKER_VOLUME_PATH out).

These changes could be brought to the other files if desired, but for now just did this POC.

Also silenced all the locale spam from mailman-web startup so it is easier to see relevant information.   This probably shouldn't use rolling for the target but 0.4 is a bit out of date.  If an updated release is done this could be changed.

postgres updated as why not, everything seems fully compat with the latest stable.