### PR TITLE
Update max header size for uwsgi deployment in Web.

### DIFF
--- a/web/mailman-web/uwsgi.ini
+++ b/web/mailman-web/uwsgi.ini
@@ -6,8 +6,8 @@ http-socket = 0.0.0.0:8000
 #Enable threading for python
 enable-threads = true
 
-#Setting uwsgi buffer size to max
-buffer-size = 65535
+# Setting uwsgi buffer size to what Apache2 supports.
+buffer-size = 8190
 
 # Move to the directory wher the django files are.
 chdir = /opt/mailman-web

--- a/web/mailman-web/uwsgi.ini
+++ b/web/mailman-web/uwsgi.ini
@@ -6,6 +6,9 @@ http-socket = 0.0.0.0:8000
 #Enable threading for python
 enable-threads = true
 
+#Setting uwsgi buffer size to max
+buffer-size = 65535
+
 # Move to the directory wher the django files are.
 chdir = /opt/mailman-web
 


### PR DESCRIPTION
Updated uwsgi from the default to the max setting 65535, this resolves an issue with large http headers that can cause 502 gateway errors when accessing mailman web interface.