### PR TITLE
Update mailman-web/urls.py address regex behavior in new django

### DIFF
--- a/web/mailman-web/urls.py
+++ b/web/mailman-web/urls.py
@@ -22,7 +22,7 @@ from django.urls import path, reverse_lazy
 from django.views.generic import RedirectView
 
 urlpatterns = [
-    path(r'^$', RedirectView.as_view(
+    path(r'', RedirectView.as_view(
         url=reverse_lazy('list_index'),
         permanent=True)),
     path(r'postorius/', include('postorius.urls')),
@@ -30,5 +30,5 @@ urlpatterns = [
     path(r'', include('django_mailman3.urls')),
     path(r'accounts/', include('allauth.urls')),
     # Django admin
-    path(r'^admin/', admin.site.urls),
+    path(r'admin/', admin.site.urls),
 ]


### PR DESCRIPTION
Regexes are not allowed in path() objects with newer django. This syncs up with the upstream urls.py at:

  https://gitlab.com/mailman/mailman-web/-/blob/master/mailman_web/urls.py

But does not modify the postorious/ vs mailman3/ and hyperkitty/ vs archives/ paths.