### PR TITLE
Drop dependency on SQLAlchemy < 1.4

### DIFF
--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -20,7 +20,6 @@ RUN --mount=type=cache,target=/root/.cache \
         && python3 -m pip install psycopg2 \
                    gunicorn==19.9.0 \
                    pymysql \
-                   'sqlalchemy<1.4.0' \
                    -r /tmp/requirements.txt \
     && apk del build-deps \
     && adduser -S mailman


### PR DESCRIPTION
Now that we support sqlalchemy 1.4+, drop pinning dependency on < 1.4