### PR TITLE
Fix MySQL connection settings in `docker-compose-mysql.yaml`

### DIFF
--- a/docker-compose-mysql.yaml
+++ b/docker-compose-mysql.yaml
@@ -13,9 +13,8 @@ services:
     depends_on:
     - database
     environment:
-    - DATABASE_URL=mysql+pymysql://mailman:mailmanpass@database/mailmandb?charset=utf8mb4&use_unicode=1
+    - DATABASE_URL=mysql://mailman:mailmanpass@database/mailmandb?charset=utf8mb4&use_unicode=1
     - DATABASE_TYPE=mysql
-    - DATABASE_CLASS=mailman.database.mysql.MySQLDatabase
     - HYPERKITTY_API_KEY=someapikey
     ports:
     - "127.0.0.1:8001:8001" # API


### PR DESCRIPTION
Solves 
```
mailman-web         | MySQL is up - continuing
mailman-web         | Copying settings_local.py ...
mailman-web         | Traceback (most recent call last):
mailman-web         |   File "manage.py", line 10, in <module>
mailman-web         |     execute_from_command_line(sys.argv)
mailman-web         |   File "/usr/lib/python3.8/site-packages/django/core/management/__init__.py", line 381, in execute_from_command_line
mailman-web         |     utility.execute()
mailman-web         |   File "/usr/lib/python3.8/site-packages/django/core/management/__init__.py", line 325, in execute
mailman-web         |     settings.INSTALLED_APPS
mailman-web         |   File "/usr/lib/python3.8/site-packages/django/conf/__init__.py", line 79, in __getattr__
mailman-web         |     self._setup(name)
mailman-web         |   File "/usr/lib/python3.8/site-packages/django/conf/__init__.py", line 66, in _setup
mailman-web         |     self._wrapped = Settings(settings_module)
mailman-web         |   File "/usr/lib/python3.8/site-packages/django/conf/__init__.py", line 157, in __init__
mailman-web         |     mod = importlib.import_module(self.SETTINGS_MODULE)
mailman-web         |   File "/usr/lib/python3.8/importlib/__init__.py", line 127, in import_module
mailman-web         |     return _bootstrap._gcd_import(name[level:], package, level)
mailman-web         |   File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
mailman-web         |   File "<frozen importlib._bootstrap>", line 991, in _find_and_load
mailman-web         |   File "<frozen importlib._bootstrap>", line 975, in _find_and_load_unlocked
mailman-web         |   File "<frozen importlib._bootstrap>", line 671, in _load_unlocked
mailman-web         |   File "<frozen importlib._bootstrap_external>", line 783, in exec_module
mailman-web         |   File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
mailman-web         |   File "/opt/mailman-web/settings.py", line 152, in <module>
mailman-web         |     'default': dj_database_url.config(conn_max_age=600)
mailman-web         |   File "/usr/lib/python3.8/site-packages/dj_database_url.py", line 55, in config
mailman-web         |     config = parse(s, engine, conn_max_age, ssl_require)
mailman-web         |   File "/usr/lib/python3.8/site-packages/dj_database_url.py", line 103, in parse
mailman-web         |     engine = SCHEMES[url.scheme] if engine is None else engine
mailman-web         | KeyError: 'mysql+pymysql'
mailman-web exited with code 1
```