### PR TITLE
Highlight diverging database URLs in `docker-compose-mysql.yaml`

### DIFF
--- a/docker-compose-mysql.yaml
+++ b/docker-compose-mysql.yaml
@@ -13,9 +13,8 @@ services:
     depends_on:
     - database
     environment:
-    - DATABASE_URL=mysql+pymysql://mailman:mailmanpass@database/mailmandb?charset=utf8mb4&use_unicode=1
+    - DATABASE_URL=mysql+pymysql://mailman:mailmanpass@database/mailmandb?charset=utf8mb4&use_unicode=1 # Do use mysql+pymysql:// here
     - DATABASE_TYPE=mysql
-    - DATABASE_CLASS=mailman.database.mysql.MySQLDatabase
     - HYPERKITTY_API_KEY=someapikey
     ports:
     - "127.0.0.1:8001:8001" # API
@@ -36,7 +35,7 @@ services:
     - /opt/mailman/web:/opt/mailman-web-data
     environment:
     - DATABASE_TYPE=mysql
-    - DATABASE_URL=mysql://mailman:mailmanpass@database/mailmandb?charset=utf8mb4
+    - DATABASE_URL=mysql://mailman:mailmanpass@database/mailmandb?charset=utf8mb4 # Do use mysql:// here
     - HYPERKITTY_API_KEY=someapikey
     - SECRET_KEY=thisisaverysecretkey
     - DYLD_LIBRARY_PATH=/usr/local/mysql/lib/


### PR DESCRIPTION
To make it easy for the user to understand that there are 2 different URL schemes, add a comment for both database URLs.