### PR TITLE
postorius: fix urls for newer django

### DIFF
--- a/postorius/mailman-web/urls.py
+++ b/postorius/mailman-web/urls.py
@@ -18,16 +18,16 @@
 
 from django.conf.urls import include
 from django.contrib import admin
-from django.urls import path, reverse_lazy
+from django.urls import re_path, reverse_lazy
 from django.views.generic import RedirectView
 
 urlpatterns = [
-    path(r'^$', RedirectView.as_view(
+    re_path(r'^$', RedirectView.as_view(
         url=reverse_lazy('list_index'),
         permanent=True)),
-    path(r'postorius/', include('postorius.urls')),
-    path(r'', include('django_mailman3.urls')),
-    path(r'accounts/', include('allauth.urls')),
+    re_path(r'postorius/', include('postorius.urls')),
+    re_path(r'', include('django_mailman3.urls')),
+    re_path(r'accounts/', include('allauth.urls')),
     # Django admin
-    path(r'^admin/', admin.site.urls),
+    re_path(r'^admin/', admin.site.urls),
 ]


### PR DESCRIPTION
`path()` no longer accepts regex paths; you must instead import and use `re_path()`. This was causing issues (among others) where the `/` to `/postorius/lists` would not work, and where `/admin` was instead `/%5Eadmin`. Django warning: 2_0.W001 

Fixes #674 