### PR TITLE
Add libldap dependency

### DIFF
--- a/postorius/Dockerfile
+++ b/postorius/Dockerfile
@@ -6,7 +6,7 @@ FROM alpine:3.19.0
 # rights for management script
 RUN --mount=type=cache,target=/root/.cache \
     set -ex \
-	&& apk add --no-cache --virtual .build-deps gcc libc-dev linux-headers \
+	&& apk add --no-cache --virtual .build-deps gcc libc-dev linux-headers libldap \
 		postgresql-dev mariadb-dev mariadb-connector-c python3-dev libffi-dev openldap-dev cargo rust \
 	&& apk add --no-cache --virtual .mailman-rundeps bash sassc tzdata \
 		postgresql-client mysql-client py3-mysqlclient curl mailcap gettext \

--- a/postorius/Dockerfile.dev
+++ b/postorius/Dockerfile.dev
@@ -10,7 +10,7 @@ ARG CLIENT_REF
 # rights for management script
 RUN --mount=type=cache,target=/root/.cache \
     set -ex \
-	&& apk add --no-cache --virtual .build-deps gcc libc-dev linux-headers \
+	&& apk add --no-cache --virtual .build-deps gcc libc-dev linux-headers libldap \
 		postgresql-dev mariadb-dev mariadb-connector-c python3-dev libffi-dev git cargo rust \
 	&& apk add --no-cache --virtual .mailman-rundeps bash sassc tzdata \
 		postgresql-client mysql-client py3-mysqlclient curl mailcap \

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -9,7 +9,7 @@ COPY requirements.txt /tmp/
 # rights for management script
 RUN --mount=type=cache,target=/root/.cache \
     set -ex \
-	&& apk add --no-cache --virtual .build-deps gcc libc-dev linux-headers \
+	&& apk add --no-cache --virtual .build-deps gcc libc-dev linux-headers libldap \
            postgresql-dev mariadb-dev mariadb-connector-c python3-dev libffi-dev openldap-dev cargo rust \
 	&& apk add --no-cache --virtual .mailman-rundeps bash sassc tzdata \
 	   postgresql-client mysql-client py3-mysqlclient curl mailcap gettext \

--- a/web/Dockerfile.dev
+++ b/web/Dockerfile.dev
@@ -11,7 +11,7 @@ ARG CLIENT_REF
 # rights for management script
 RUN --mount=type=cache,target=/root/.cache \
     set -ex \
-    && apk add --no-cache --virtual .build-deps gcc libc-dev linux-headers git \
+    && apk add --no-cache --virtual .build-deps gcc libc-dev linux-headers git libldap \
         postgresql-dev mariadb-dev mariadb-connector-c python3-dev libffi-dev openldap-dev cargo rust \
     && apk add --no-cache --virtual .mailman-rundeps bash sassc pcre-dev tzdata \
         python3 py3-pip postgresql-client mysql-client py3-mysqlclient \


### PR DESCRIPTION
`django-auth-ldap` is installed, but it depends on the system package `libldap`, which was not installed.