### PR TITLE
fix: Typos in comments

### DIFF
--- a/postorius/mailman-web/uwsgi.ini
+++ b/postorius/mailman-web/uwsgi.ini
@@ -3,7 +3,7 @@
 uwsgi-socket = 0.0.0.0:8080
 http-socket = 0.0.0.0:8000
 
-# Move to the directory wher the django files are.
+# Move to the directory where the django files are.
 chdir = /opt/mailman-web
 
 # Use the wsgi file provided with the django project.
@@ -14,7 +14,7 @@ master = true
 processes = 2
 threads = 2
 
-# Drop privielges and don't run as root.
+# Drop privileges and don't run as root.
 uid = mailman
 gid = mailman
 

--- a/web/mailman-web/uwsgi.ini
+++ b/web/mailman-web/uwsgi.ini
@@ -3,13 +3,13 @@
 uwsgi-socket = 0.0.0.0:8080
 http-socket = 0.0.0.0:8000
 
-#Enable threading for python
+# Enable threading for python
 enable-threads = true
 
 # Setting uwsgi buffer size to what Apache2 supports.
 buffer-size = 8190
 
-# Move to the directory wher the django files are.
+# Move to the directory where the django files are.
 chdir = /opt/mailman-web
 
 # Use the wsgi file provided with the django project.
@@ -20,7 +20,7 @@ master = true
 processes = 2
 threads = 2
 
-# Drop privielges and don't run as root.
+# Drop privileges and don't run as root.
 uid = mailman
 gid = mailman
 


### PR DESCRIPTION
I noticed a few minor typos in the comments of `uwsgi.ini` that bothered me just enough to open a PR for them (: