### PR TITLE
issue 549 prevent mailman-web dns lookup from throwing

### DIFF
--- a/web/mailman-web/settings.py
+++ b/web/mailman-web/settings.py
@@ -29,7 +29,7 @@ https://docs.djangoproject.com/en/1.8/ref/settings/
 import os
 import dj_database_url
 import sys
-from socket import gethostbyname
+from socket import gethostbyname, gaierror
 
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 
@@ -50,9 +50,14 @@ SITE_ID = 1
 ALLOWED_HOSTS = [
     "localhost",  # Archiving API from Mailman, keep it.
     "mailman-web",
-    gethostbyname("mailman-web"),
     os.environ.get('SERVE_FROM_DOMAIN'),
 ]
+
+try:
+    ALLOWED_HOSTS.append(gethostbyname("mailman-web")) # only add if this resolves
+except gaierror:
+    pass
+
 ALLOWED_HOSTS.extend(os.getenv("DJANGO_ALLOWED_HOSTS", "").split(","))
 
 # Mailman API credentials


### PR DESCRIPTION
Addresses https://github.com/maxking/docker-mailman/issues/549

There might be some neater options than just swallowing the exception, but I've tried to keep the change minimal.

Alternatives -
- DJANGO_ALLOWED_HOSTS could override rather than extend, but that would be a breaking change. 
- We could introduce another env var to override the default behavior. 

