### PR TITLE
Avoid Django 3.2+ warning

### DIFF
--- a/postorius/mailman-web/settings.py
+++ b/postorius/mailman-web/settings.py
@@ -143,6 +143,11 @@ DATABASES = {
     'default': dj_database_url.config(conn_max_age=600)
 }
 
+# Avoid Django 3.2+ warning
+# https://github.com/maxking/docker-mailman/issues/595
+DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
+
+
 # If you're behind a proxy, use the X-Forwarded-Host header
 # See https://docs.djangoproject.com/en/1.8/ref/settings/#use-x-forwarded-host
 USE_X_FORWARDED_HOST = True

--- a/web/mailman-web/settings.py
+++ b/web/mailman-web/settings.py
@@ -156,6 +156,11 @@ DATABASES = {
     'default': dj_database_url.config(conn_max_age=600)
 }
 
+# Avoid Django 3.2+ warning
+# https://github.com/maxking/docker-mailman/issues/595
+DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
+
+
 # If you're behind a proxy, use the X-Forwarded-Host header
 # See https://docs.djangoproject.com/en/1.8/ref/settings/#use-x-forwarded-host
 USE_X_FORWARDED_HOST = True


### PR DESCRIPTION
Should fix #595 for everyone, without the need of migrations.

An alternative would be to switch to `BigAutoField` in order to support really big Mailman installations, and add the migrations described [here](https://dev.to/weplayinternet/upgrading-to-django-3-2-and-fixing-defaultautofield-warnings-518n#migrations) to the `docker-entrypoint.sh` files. I can update this PR accordingly if you prefer that option.