### PR TITLE
Bump postgres to 12 from 11 in compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -51,7 +51,7 @@ services:
     - POSTGRES_DB=mailmandb
     - POSTGRES_USER=mailman
     - POSTGRES_PASSWORD=mailmanpass
-    image: postgres:11-alpine
+    image: postgres:12-alpine
     volumes:
     - /opt/mailman/database:/var/lib/postgresql/data
     networks:


### PR DESCRIPTION
Since Django 4.2 doesn't support below that, we need to bump to Postgres 12.

Django 4.1 is no longer supported, so 4.2 is the lowest version we support here.