### PR TITLE
Add TLS options for SMTP

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,9 @@ These are the variables that you MUST change in your docker-compose.yaml before 
 - `SMTP_PORT`	: use this port. 25, 587, whatever your host asks for.
 - `SMTP_HOST_USER`: authenticate this user
 - `SMTP_HOST_PASSWORD`: and use this password
+- `SMTP_SECURE_MODE`: security mode for smtp connection - can be `smtp` (no encryption), `smtps` or `starttls`
+- `SMTP_VERIFY_HOSTNAME`: defaults to `true` - verify, that certificate hostname is identical to `SMTP_HOST`
+- `SMTP_VERIFY_CERT`: defaults to `true` - verify, that certificate is valid
 
 For more details on how to configure this image, please look [Mailman-core's
 Readme](core/)

--- a/core/README.md
+++ b/core/README.md
@@ -60,6 +60,8 @@ standard version of docker-compose.yaml from this repository.
 
 - `SMTP_PORT`: Port used for SMTP. Default is `25`.
 
+- `SMTP_SECURE_MODE`: Security mode (encryption) used for SMTP. Default is `smtp`. Can also be `starttls` or `smtps`.
+
 - `HYPERKITTY_URL`: Default value is `http://mailman-web:8000/hyperkitty`
 
 In case of a need for fine tuning of REST API web-server that uses [Gunicorn](https://docs.gunicorn.org/en/stable/settings.html) (e.g. for raising of timeouts) `/opt/mailman/core/gunicorn-extra.cfg` file could be provided holding necessary configuration options.
@@ -106,6 +108,9 @@ lmtp_host: $MM_HOSTNAME
 lmtp_port: 8024
 smtp_host: $SMTP_HOST
 smtp_port: $SMTP_PORT
+smtp_secure_mode: $SMTP_SECURE_MODE
+smtp_verify_hostname: $SMTP_VERIFY_HOSTNAME
+smtp_verify_cert: $SMTP_VERIFY_CERT
 configuration: python:mailman.config.exim4
 
 [runner.retry]

--- a/core/docker-entrypoint.sh
+++ b/core/docker-entrypoint.sh
@@ -44,15 +44,15 @@ if [[ ! -v SMTP_PORT ]]; then
 fi
 
 if [[ ! -v SMTP_SECURE_MODE ]]; then
-	export SMTP_SECURE_MODE="starttls"
+	export SMTP_SECURE_MODE="smtp"
 fi
 
 if [[ ! -v SMTP_VERIFY_HOSTNAME ]]; then
-	export SMTP_VERIFY_HOSTNAME="True"
+	export SMTP_VERIFY_HOSTNAME="true"
 fi
 
 if [[ ! -v SMTP_VERIFY_CERT ]]; then
-	export SMTP_VERIFY_CERT="True"
+	export SMTP_VERIFY_CERT="true"
 fi
 
 # Check if REST port, username, and password are set, if not, set them

--- a/core/docker-entrypoint.sh
+++ b/core/docker-entrypoint.sh
@@ -43,6 +43,18 @@ if [[ ! -v SMTP_PORT ]]; then
 	export SMTP_PORT=25
 fi
 
+if [[ ! -v SMTP_SECURE_MODE ]]; then
+	export SMTP_SECURE_MODE="starttls"
+fi
+
+if [[ ! -v SMTP_VERIFY_HOSTNAME ]]; then
+	export SMTP_VERIFY_HOSTNAME="True"
+fi
+
+if [[ ! -v SMTP_VERIFY_CERT ]]; then
+	export SMTP_VERIFY_CERT="True"
+fi
+
 # Check if REST port, username, and password are set, if not, set them
 # to default values.
 if [[ ! -v MAILMAN_REST_PORT ]]; then
@@ -144,6 +156,9 @@ smtp_host: $SMTP_HOST
 smtp_port: $SMTP_PORT
 smtp_user: $SMTP_HOST_USER
 smtp_pass: $SMTP_HOST_PASSWORD
+smtp_secure_mode: $SMTP_SECURE_MODE
+smtp_verify_hostname: $SMTP_VERIFY_HOSTNAME
+smtp_verify_cert: $SMTP_VERIFY_CERT
 configuration: python:mailman.config.exim4
 
 EOF
@@ -167,6 +182,9 @@ smtp_host: $SMTP_HOST
 smtp_port: $SMTP_PORT
 smtp_user: $SMTP_HOST_USER
 smtp_pass: $SMTP_HOST_PASSWORD
+smtp_secure_mode: $SMTP_SECURE_MODE
+smtp_verify_hostname: $SMTP_VERIFY_HOSTNAME
+smtp_verify_cert: $SMTP_VERIFY_CERT
 configuration: /etc/postfix-mailman.cfg
 
 EOF


### PR DESCRIPTION
Hello,

I am using docker-mailman in combination to https://github.com/mailcow/mailcow-dockerized - and for signing all outgoing mails with DKIM, mailman has to send them authenticated. For security reasons, I do not allow unencrypted authentication on the server (STARTTLS).

I've added some options to enable TLS or SSL when using exim or postfix as MTA. They all default to the standard values according to the mailman docs.