### PR TITLE
[web, postorius] Fix libldap installation package group

### DIFF
--- a/postorius/Dockerfile
+++ b/postorius/Dockerfile
@@ -6,9 +6,9 @@ FROM alpine:3.20.0
 # rights for management script
 RUN --mount=type=cache,target=/root/.cache \
     set -ex \
-	&& apk add --no-cache --virtual .build-deps gcc libc-dev linux-headers libldap \
+	&& apk add --no-cache --virtual .build-deps gcc libc-dev linux-headers \
 		postgresql-dev mariadb-dev mariadb-connector-c python3-dev libffi-dev openldap-dev cargo rust \
-	&& apk add --no-cache --virtual .mailman-rundeps bash sassc tzdata \
+	&& apk add --no-cache --virtual .mailman-rundeps bash sassc tzdata libldap \
 		postgresql-client mysql-client py3-mysqlclient curl mailcap gettext \
 		python3 py3-pip libffi libuuid pcre-dev py-cryptography \
 	&& python3 -m pip install --break-system-packages -U 'Django<4.3' pip setuptools wheel \

--- a/postorius/Dockerfile.dev
+++ b/postorius/Dockerfile.dev
@@ -10,9 +10,9 @@ ARG CLIENT_REF
 # rights for management script
 RUN --mount=type=cache,target=/root/.cache \
     set -ex \
-	&& apk add --no-cache --virtual .build-deps gcc libc-dev linux-headers libldap \
+	&& apk add --no-cache --virtual .build-deps gcc libc-dev linux-headers \
 		postgresql-dev mariadb-dev mariadb-connector-c python3-dev libffi-dev git cargo rust \
-	&& apk add --no-cache --virtual .mailman-rundeps bash sassc tzdata \
+	&& apk add --no-cache --virtual .mailman-rundeps bash sassc tzdata libldap \
 		postgresql-client mysql-client py3-mysqlclient curl mailcap \
 		python3 py3-pip libffi gettext py-cryptography \
     && python3 -m pip install --break-system-packages -U pip setuptools wheel \

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -9,9 +9,9 @@ COPY requirements.txt /tmp/
 # rights for management script
 RUN --mount=type=cache,target=/root/.cache \
     set -ex \
-	&& apk add --no-cache --virtual .build-deps gcc libc-dev linux-headers libldap \
+	&& apk add --no-cache --virtual .build-deps gcc libc-dev linux-headers \
            postgresql-dev mariadb-dev mariadb-connector-c python3-dev libffi-dev openldap-dev cargo rust \
-	&& apk add --no-cache --virtual .mailman-rundeps bash sassc tzdata \
+	&& apk add --no-cache --virtual .mailman-rundeps bash sassc tzdata libldap \
 	   postgresql-client mysql-client py3-mysqlclient curl mailcap gettext \
 	   python3 py3-pip xapian-core xapian-bindings-python3 libffi pcre-dev py-cryptography \
 	&& python3 -m pip install --break-system-packages -U 'Django<4.3' pip setuptools wheel \

--- a/web/Dockerfile.dev
+++ b/web/Dockerfile.dev
@@ -11,9 +11,9 @@ ARG CLIENT_REF
 # rights for management script
 RUN --mount=type=cache,target=/root/.cache \
     set -ex \
-    && apk add --no-cache --virtual .build-deps gcc libc-dev linux-headers git libldap \
+    && apk add --no-cache --virtual .build-deps gcc libc-dev linux-headers git \
         postgresql-dev mariadb-dev mariadb-connector-c python3-dev libffi-dev openldap-dev cargo rust \
-    && apk add --no-cache --virtual .mailman-rundeps bash sassc pcre-dev tzdata \
+    && apk add --no-cache --virtual .mailman-rundeps bash sassc pcre-dev tzdata libldap \
         python3 py3-pip postgresql-client mysql-client py3-mysqlclient \
         curl mailcap xapian-core xapian-bindings-python3 libffi gettext py-cryptography \
     && python3 -m pip install --break-system-packages -U pip setuptools wheel \


### PR DESCRIPTION
#### Overview

The libldap package is not installed in the `mailman-web:0.5` and `postorius` images despite being listed as a dependency in the `Dockerfile`. This issue arises because `libldap` is included in the `.build-deps` virtual package group, which is removed at the end of the build process, causing the package to be uninstalled.

This commit addresses the issue by moving `libldap` from the `.build-deps` virtual package group to the `.mailman-rundeps` virtual package group in both the `web` and `postorius`-`Dockerfiles`. This ensures that `libldap` remains installed in the final image, as it is now part of the runtime dependencies.

Changes:
- Move `libldap` installation from `.build-deps` to `.mailman-rundeps` in `postorius/Dockerfile`;
- Move `libldap` installation from `.build-deps` to `.mailman-rundeps` in `web/Dockerfile`.

These changes are necessary to ensure that the `libldap` package is available in the running containers, preventing runtime errors related to missing LDAP dependencies.

#### Comments

Closes #703 