### PR TITLE
fix: core startup fails if /opt/mailman/mailman-extra.cfg is read-only

### DIFF
--- a/core/docker-entrypoint.sh
+++ b/core/docker-entrypoint.sh
@@ -247,7 +247,7 @@ echo "HYPERKITTY_API_KEY not defined, skipping HyperKitty setup..."
 fi
 
 # Now chown the places where mailman wants to write stuff.
-chown -R mailman /opt/mailman
+chown -R mailman /opt/mailman/var
 
 # Generate the LMTP files for postfix if needed.
 su-exec mailman mailman aliases


### PR DESCRIPTION
Follow-up to #86, after studying the content of /opt/mailman, only the var sub-folder seems important as writable.