### PR TITLE
Create the var directory before trying to chown.

### DIFF
--- a/core/docker-entrypoint.sh
+++ b/core/docker-entrypoint.sh
@@ -247,7 +247,17 @@ echo "HYPERKITTY_API_KEY not defined, skipping HyperKitty setup..."
 fi
 
 # Now chown the places where mailman wants to write stuff.
-chown -R mailman /opt/mailman/var
+VAR_DIR="/opt/mailman/var"
+# Check if the directory exists
+if [ ! -d "$VAR_DIR" ]; then
+  # Directory does not exist, so create it
+  mkdir -p "$VAR_DIR"
+  echo "Directory $VAR_DIR created."
+else
+  echo "Directory $VAR_DIR already exists."
+fi
+
+chown -R mailman $VAR_DIR
 
 # Generate the LMTP files for postfix if needed.
 su-exec mailman mailman aliases


### PR DESCRIPTION
During cold start, var directory may not exist and we try to chown
the var directory which fails if it doesn't exist. We want to make
and chown the var directory in that case otherwise, mailman will not
be able to write to path `/opt/mailman` to create it's own var
directory.

This should fix the CI failures are we are seeing.
