### PR TITLE
Migrate to using compose plugin and healthchecks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,16 +107,16 @@ $ docker inspect --format '{{json .Config.Labels }}' mailman-web | python -m jso
 ## Dependencies
 
 - Docker
-- Docker-compose
+- Docker-compose-plugin
 
 To install these on Ubuntu/Debian:
 
 ```
-$ sudo apt install docker.io docker-compose
+$ sudo apt install docker.io docker-compose-plugin
 ```
 
 For other systems, you can read the official Docker documentation to install
-[Docker from here][5] and [docker-compose from here][6].
+[Docker from here][5] and [docker compose from here][6].
 
 
 ## Configuration
@@ -239,7 +239,7 @@ $ mkdir -p /opt/mailman/web
 $ git clone https://github.com/maxking/docker-mailman
 $ cd docker-mailman
 # Change some configuration variables as mentioned above.
-$ docker-compose up -d
+$ docker compose up -d
 ```
 
 Note that the web frontend in the mailman-web container is, by default, only
@@ -453,7 +453,7 @@ If you have been using the default search indexing engine, you might have to
 re-index emails using the following command:
 
 ```bash
-$ docker-compose exec mailman-web ./manage.py rebuild_index
+$ docker compose exec mailman-web ./manage.py rebuild_index
 ```
 
 This command can take some time if you a lot of emails, so please be patient!

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -12,7 +12,8 @@ services:
     links:
     - database:database
     depends_on:
-    - database
+      database:
+        condition: service_healthy
     environment:
     - DATABASE_URL=postgresql://mailman:mailmanpass@database/mailmandb
     - DATABASE_TYPE=postgres
@@ -30,7 +31,8 @@ services:
     hostname: mailman-web
     restart: unless-stopped
     depends_on:
-    - database
+      database:
+        condition: service_healthy
     links:
     - mailman-core:mailman-core
     - database:database
@@ -54,6 +56,11 @@ services:
     image: postgres:12-alpine
     volumes:
     - /opt/mailman/database:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready --dbname mailmandb --username mailman"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
     networks:
       mailman:
 

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -4,10 +4,10 @@ set -e
 # If the DB environment variable is not set, use postgres.x
 if [ "$DB" = "postgres" ] || [ -z $DB ]
 then
-	docker-compose -f docker-compose.yaml -f tests/docker-test.yaml up -d
+	docker compose -f docker-compose.yaml -f tests/docker-test.yaml up -d
 elif [ "$DB" = "mysql" ]
 then
-	docker-compose -f docker-compose-mysql.yaml -f tests/docker-test.yaml up -d
+	docker compose -f docker-compose-mysql.yaml -f tests/docker-test.yaml up -d
 fi
 
 # Print the IP Addresses of the Containers.
@@ -15,7 +15,7 @@ docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' mai
 docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' mailman-web
 
 # Make sure all the containers are running.
-docker-compose ps
+docker compose ps
 
 # Sleep for a while and check again if the containers are up.
 sleep 60


### PR DESCRIPTION
This commit migrates docs and tests to use docker-commpose-plugin
instead of the old docker-compose package. This allows us to use
new APIs like healthchecks for containers.
