### PR TITLE
Adapt build script to aarch64 platform

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -10,26 +10,52 @@ export BUILD_ROLLING="${1:-no}"
 
 DOCKER=docker
 
+# The following variables can be overridden using env-variables
+
+# Set tag namespace (i.e. ghcr.io/<org> for github package registry)
+TAG_NS="${TAG_NS:-maxking}"
+# Set default platforms to build
+PLATFORM="${PLATFORM:-linux/arm64/v8,linux/amd64}"
+# Platform to load into docker after build
+# Can only load one platform, should match host
+PLATFORM_TO_LOAD="linux/amd64"
+# set env-var PUSH to yes to push to registry
+PUSH="${PUSH:-no}"
+
+build() {
+    if [ "$PUSH" = "yes" ]; then
+        $DOCKER buildx build --platform $PLATFORM $@ --push
+    else
+        $DOCKER buildx build --platform $PLATFORM $@
+    fi
+    $DOCKER buildx build --platform $PLATFORM_TO_LOAD $@ --load
+}
+
+# Check if the builder with name "multiarch" exists, if not create it
+if ! docker buildx ls | grep -q multiarch; then
+  docker buildx create --name multiarch --driver docker-container --use
+fi
+
 if [ "$BUILD_ROLLING" = "yes" ]; then
     echo "Building rolling releases..."
     # Build the mailman-core image.
-    $DOCKER build -f core/Dockerfile.dev \
+    build -f core/Dockerfile.dev \
             --label version.git_commit="$COMMIT_ID" \
-            -t maxking/mailman-core:rolling core/
+            -t $TAG_NS/mailman-core:rolling core/
 
     # Build the mailman-web image.
-    $DOCKER build -f web/Dockerfile.dev \
+    build -f web/Dockerfile.dev \
             --label version.git_commit="$COMMIT_ID" \
-            -t maxking/mailman-web:rolling web/
+            -t $TAG_NS/mailman-web:rolling web/
 
     # build the postorius image.
-    $DOCKER build -f postorius/Dockerfile.dev\
-			--label version.git_commit="$COMMIT_ID"\
-			-t maxking/postorius:rolling postorius/
+    build -f postorius/Dockerfile.dev\
+            --label version.git_commit="$COMMIT_ID"\
+            -t $TAG_NS/postorius:rolling postorius/
 else
     echo "Building stable releases..."
     # Build the stable releases.
-    $DOCKER build -t maxking/mailman-core:rolling core/
-    $DOCKER build -t maxking/mailman-web:rolling web/
-    $DOCKER build -t maxking/postorius:rolling postorius/
+    build --tag $TAG_NS/mailman-core:rolling core/
+    build --tag $TAG_NS/mailman-web:rolling web/ 
+    build --tag $TAG_NS/postorius:rolling postorius/ 
 fi

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -17,7 +17,8 @@ RUN --mount=type=cache,target=/root/.cache \
 	&& python3 -m pip install --break-system-packages -U 'Django<4.3' pip setuptools wheel \
 	&& pip install --break-system-packages -r /tmp/requirements.txt \
 		whoosh \
-		uwsgi \
+		# later builds of uwsgi don't compile on aarch64
+		uwsgi==2.0.25 \
 		psycopg2 \
 		dj-database-url \
 		mysqlclient \


### PR DESCRIPTION
I need to use mailman on a Hetzner cloud instance. The images are not multi-arch, so I adapted the builds script to run multi-arch docker builds. 

I ran into problems compiling the latest uwsgi (2.0.28) - (or one of its plugins, since postorius seemed to compile just fine on 2.0.28). This was fixed by pinning uwsgi to 2.0.25 for the mailman-web docker image. 