### PR TITLE
Use mistune version 3.0.*, not 3.1.

### DIFF
--- a/web/requirements.txt
+++ b/web/requirements.txt
@@ -2,3 +2,4 @@ mailmanclient==3.3.5
 postorius==1.3.13
 hyperkitty==1.3.12
 django-mailman3==1.3.15
+mistune~=3.0.0


### PR DESCRIPTION
With mistune 3.1.0 or later, exceptions are thrown when rendering certain messages.

See https://lists.mailman3.org/archives/list/mailman-users@mailman3.org/thread/TYPG6BVLVGNS5RTDJVN5YEC26EVWZMAQ/